### PR TITLE
Add compact PyTorch MEG LOSO baselines

### DIFF
--- a/.github/workflows/pytorch_cached_public_meg.yml
+++ b/.github/workflows/pytorch_cached_public_meg.yml
@@ -13,6 +13,9 @@ on:
         required: false
         default: '/home/github-runner/.cache/datasets'
 
+env:
+  CACHE_ROOT: ${{ github.event.inputs.cache_root || '/home/github-runner/.cache/datasets' }}
+
 jobs:
   cached-public-meg-benchmark:
     name: Cached public MEG benchmark
@@ -31,9 +34,7 @@ jobs:
           which python3
           python3 --version
           df -h /home/github-runner || true
-          find "${CACHE_ROOT:-/home/github-runner/.cache/datasets}" -maxdepth 2 -type d | head -100 || true
-        env:
-          CACHE_ROOT: ${{ inputs.cache_root || '/home/github-runner/.cache/datasets' }}
+          find "${CACHE_ROOT}" -maxdepth 2 -type d | head -100 || true
 
       - name: Check Python dependencies
         run: |
@@ -62,8 +63,6 @@ jobs:
             --patience 3 \
             --batch-size 32 \
             --device cpu
-        env:
-          CACHE_ROOT: ${{ inputs.cache_root || '/home/github-runner/.cache/datasets' }}
 
       - name: Upload benchmark outputs
         if: always()

--- a/.github/workflows/pytorch_cached_public_meg.yml
+++ b/.github/workflows/pytorch_cached_public_meg.yml
@@ -1,0 +1,75 @@
+name: PyTorch cached public MEG benchmark
+
+on:
+  pull_request:
+    paths:
+      - 'pytorch_meg_baselines.py'
+      - 'run_cached_public_meg_baselines.py'
+      - '.github/workflows/pytorch_cached_public_meg.yml'
+  workflow_dispatch:
+    inputs:
+      cache_root:
+        description: 'Dataset cache root on the self-hosted runner'
+        required: false
+        default: '/home/github-runner/.cache/datasets'
+
+jobs:
+  cached-public-meg-benchmark:
+    name: Cached public MEG benchmark
+    runs-on: [self-hosted, linux]
+    timeout-minutes: 180
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Show environment
+        run: |
+          set -euxo pipefail
+          hostname
+          pwd
+          which python3
+          python3 --version
+          df -h /home/github-runner || true
+          find "${CACHE_ROOT:-/home/github-runner/.cache/datasets}" -maxdepth 2 -type d | head -100 || true
+        env:
+          CACHE_ROOT: ${{ inputs.cache_root || '/home/github-runner/.cache/datasets' }}
+
+      - name: Check Python dependencies
+        run: |
+          python3 - <<'PY'
+          import importlib.util
+          missing = [m for m in ['numpy', 'scipy', 'torch'] if importlib.util.find_spec(m) is None]
+          optional_missing = [m for m in ['mne'] if importlib.util.find_spec(m) is None]
+          print('missing_required=', missing)
+          print('missing_optional=', optional_missing)
+          if missing:
+              raise SystemExit('Required Python packages missing: ' + ', '.join(missing))
+          PY
+
+      - name: Run compact neural baselines on cached public MEG data
+        run: |
+          set -euxo pipefail
+          python3 run_cached_public_meg_baselines.py \
+            --cache-root "${CACHE_ROOT}" \
+            --output-dir results/cached_public_meg \
+            --models eegnet lfcnn varcnn hgrn \
+            --max-subjects 4 \
+            --max-target-subjects 2 \
+            --max-classes 16 \
+            --max-trials-per-subject-class 30 \
+            --epochs 8 \
+            --patience 3 \
+            --batch-size 32 \
+            --device cpu
+        env:
+          CACHE_ROOT: ${{ inputs.cache_root || '/home/github-runner/.cache/datasets' }}
+
+      - name: Upload benchmark outputs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cached-public-meg-baseline-results
+          path: |
+            results/cached_public_meg/
+          if-no-files-found: warn

--- a/.github/workflows/pytorch_public_meg_hosted.yml
+++ b/.github/workflows/pytorch_public_meg_hosted.yml
@@ -52,21 +52,27 @@ jobs:
       - name: Run compact neural baselines on public Visual 92 MEG subset
         run: |
           set -euxo pipefail
-          python run_cached_public_meg_baselines.py \
-            --cache-root "${DATA_ROOT}" \
-            --output-dir results/public_visual92_hosted \
-            --models eegnet lfcnn varcnn hgrn \
-            --max-subjects 4 \
-            --max-target-subjects 2 \
-            --max-classes 4 \
-            --max-trials-per-subject-class 10 \
-            --epochs 2 \
-            --patience 1 \
-            --batch-size 16 \
-            --tmin 0.0 \
-            --tmax 0.5 \
-            --resample-hz 100 \
-            --device cpu
+          mkdir -p results/public_visual92_hosted
+          {
+            echo "DATA_ROOT=${DATA_ROOT}"
+            echo "Top-level Visual92 files:"
+            find "${DATA_ROOT}" -maxdepth 2 -type f | sort | sed -n '1,80p'
+            python run_cached_public_meg_baselines.py \
+              --cache-root "${DATA_ROOT}" \
+              --output-dir results/public_visual92_hosted \
+              --models eegnet lfcnn varcnn hgrn \
+              --max-subjects 4 \
+              --max-target-subjects 2 \
+              --max-classes 4 \
+              --max-trials-per-subject-class 10 \
+              --epochs 2 \
+              --patience 1 \
+              --batch-size 16 \
+              --tmin 0.0 \
+              --tmax 0.5 \
+              --resample-hz 100 \
+              --device cpu
+          } 2>&1 | tee results/public_visual92_hosted/run.log
 
       - name: Upload hosted public benchmark outputs
         if: always()

--- a/.github/workflows/pytorch_public_meg_hosted.yml
+++ b/.github/workflows/pytorch_public_meg_hosted.yml
@@ -1,0 +1,79 @@
+name: PyTorch public MEG benchmark hosted
+
+on:
+  pull_request:
+    paths:
+      - 'pytorch_meg_baselines.py'
+      - 'run_cached_public_meg_baselines.py'
+      - '.github/workflows/pytorch_public_meg_hosted.yml'
+  workflow_dispatch:
+
+jobs:
+  public-meg-hosted-benchmark:
+    name: Public MEG benchmark on GitHub-hosted runner
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Cache MNE visual dataset
+        uses: actions/cache@v4
+        with:
+          path: mne_data
+          key: mne-visual92-v1
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install numpy scipy mne torch --index-url https://pypi.org/simple
+
+      - name: Download public MNE Visual 92 MEG dataset
+        run: |
+          set -euxo pipefail
+          python - <<'PY' | tee visual92_path.txt
+          import mne
+          path = mne.datasets.visual_92_categories.data_path(
+              path='mne_data',
+              update_path=False,
+              download=True,
+              verbose=True,
+          )
+          print(path)
+          PY
+          echo "DATA_ROOT=$(tail -n 1 visual92_path.txt)" >> "$GITHUB_ENV"
+
+      - name: Run compact neural baselines on public Visual 92 MEG subset
+        run: |
+          set -euxo pipefail
+          python run_cached_public_meg_baselines.py \
+            --cache-root "${DATA_ROOT}" \
+            --output-dir results/public_visual92_hosted \
+            --models eegnet lfcnn varcnn hgrn \
+            --max-subjects 4 \
+            --max-target-subjects 2 \
+            --max-classes 4 \
+            --max-trials-per-subject-class 10 \
+            --epochs 2 \
+            --patience 1 \
+            --batch-size 16 \
+            --tmin 0.0 \
+            --tmax 0.5 \
+            --resample-hz 100 \
+            --device cpu
+
+      - name: Upload hosted public benchmark outputs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: public-visual92-hosted-baseline-results
+          path: |
+            results/public_visual92_hosted/
+            visual92_path.txt
+          if-no-files-found: warn

--- a/.github/workflows/pytorch_public_meg_hosted.yml
+++ b/.github/workflows/pytorch_public_meg_hosted.yml
@@ -38,14 +38,16 @@ jobs:
         run: |
           set -euxo pipefail
           python - <<'PY' | tee visual92_path.txt
+          from pathlib import Path
           import mne
+          download_root = Path.cwd() / 'mne_data'
           path = mne.datasets.visual_92_categories.data_path(
-              path='mne_data',
+              path=str(download_root),
               update_path=False,
               download=True,
               verbose=True,
           )
-          print(path)
+          print(Path(path).resolve())
           PY
           echo "DATA_ROOT=$(tail -n 1 visual92_path.txt)" >> "$GITHUB_ENV"
 

--- a/README_PYTORCH_BASELINES.md
+++ b/README_PYTORCH_BASELINES.md
@@ -1,0 +1,41 @@
+# PyTorch compact MEG baselines
+
+This branch adds strict no-calibration LOSO baselines inspired by the papers we discussed:
+
+- `eegnet`: EEGNet-style temporal + depthwise spatial CNN.
+- `lfcnn`: LF-CNN-style spatial latent filters plus temporal filtering.
+- `varcnn`: VAR-CNN-style lag/dynamics CNN.
+- `hgrn`: HGRN-style spatial projection + GRU + attention pooling.
+
+The runner expects a trial tensor `X` shaped `trials x channels x time`, labels `y`, and subject IDs `subjects`. For each held-out subject, the code fits normalization, trains the model, and does early stopping using source subjects only. The target subject is used only for final evaluation.
+
+## Export from the existing MATLAB pipeline
+
+```matlab
+exportTrialTensorForPyTorch('data', [1:4, 6, 8:10, 13:27], ...
+    'meg_trials_for_pytorch.mat', 0.2, 0.2, nan, inf, [0, inf]);
+```
+
+The exporter reuses `preprocessFeatures.m`, so filtering, downsampling, and window extraction stay aligned with the existing MATLAB baselines. Null-window pseudo-trials are omitted because these neural baselines are multiclass stimulus classifiers.
+
+## Run the neural LOSO baselines
+
+```bash
+python pytorch_meg_baselines.py \
+  --data meg_trials_for_pytorch.mat \
+  --models eegnet lfcnn varcnn hgrn \
+  --epochs 80 \
+  --patience 15 \
+  --batch-size 64 \
+  --output-prefix results/pytorch_loso
+```
+
+The output is written to `results/pytorch_loso.csv` and `results/pytorch_loso.json` with fold-level accuracy, balanced accuracy, chance level, held-out subject, and early-stopping epoch.
+
+## Smoke test
+
+```bash
+python pytorch_meg_baselines.py --smoke-test
+```
+
+I ran this smoke test locally with synthetic data. It verifies that all four model families train and evaluate end-to-end, but it is not a real MEG benchmark.

--- a/exportTrialTensorForPyTorch.m
+++ b/exportTrialTensorForPyTorch.m
@@ -1,0 +1,60 @@
+function exportTrialTensorForPyTorch(dataFolder, participantIDs, outputFile, windowSize, trainWindowCenter, nullWindowCenter, newFramerate, frequencyRange)
+% exportTrialTensorForPyTorch Export FieldTrip MEG trials for PyTorch LOSO baselines.
+%
+% The output MAT file contains:
+%   X        : trials x channels x time tensor
+%   y        : trials x 1 labels
+%   subjects : trials x 1 participant IDs
+%
+% This uses the same preprocessFeatures.m path as the existing MATLAB baselines
+% for filtering, downsampling, and window extraction. Null-window trials are not
+% exported because the PyTorch baselines are multiclass stimulus classifiers.
+
+    arguments
+        dataFolder char = '.';
+        participantIDs (1, :) double {mustBeInteger, mustBePositive} = [1:4, 6, 8:10, 13:27];
+        outputFile char = 'meg_trials_for_pytorch.mat';
+        windowSize (1, 1) double = 0.2;
+        trainWindowCenter (1, 1) double = 0.2;
+        nullWindowCenter (1, 1) double = nan; %#ok<INUSA> Kept for API symmetry; neural export omits null trials.
+        newFramerate (1, 1) double = inf;
+        frequencyRange (1, 2) double = [0, inf];
+    end
+
+    XParts = {};
+    yParts = {};
+    subjectParts = {};
+
+    for i = 1:numel(participantIDs)
+        participantID = participantIDs(i);
+        loaded = load([dataFolder filesep 'Part' int2str(participantID) 'Data.mat'], 'data');
+        data = loaded.data;
+        labels = data.trialinfo(:);
+        nChannels = size(data.trial{1}, 1);
+
+        % Disable null-window extraction for the neural baselines.
+        [stimuliFeaturesCell, ~] = preprocessFeatures(data, frequencyRange, newFramerate, windowSize, trainWindowCenter, nan);
+        nTrials = numel(stimuliFeaturesCell);
+        nWindowSamples = numel(stimuliFeaturesCell{1}) / nChannels;
+        assert(mod(nWindowSamples, 1) == 0, 'Window feature length is not divisible by number of channels.');
+
+        XPart = zeros(nTrials, nChannels, nWindowSamples, 'single');
+        for t = 1:nTrials
+            XPart(t, :, :) = single(reshape(stimuliFeaturesCell{t}, nChannels, nWindowSamples));
+        end
+
+        XParts{end + 1} = XPart; %#ok<AGROW>
+        yParts{end + 1} = labels; %#ok<AGROW>
+        subjectParts{end + 1} = participantID * ones(nTrials, 1); %#ok<AGROW>
+    end
+
+    X = cat(1, XParts{:}); %#ok<NASGU>
+    y = cat(1, yParts{:}); %#ok<NASGU>
+    subjects = cat(1, subjectParts{:}); %#ok<NASGU>
+    exportedParticipantIDs = participantIDs; %#ok<NASGU>
+    preprocessing = struct('windowSize', windowSize, 'trainWindowCenter', trainWindowCenter, ...
+        'newFramerate', newFramerate, 'frequencyRange', frequencyRange); %#ok<NASGU>
+
+    save(outputFile, 'X', 'y', 'subjects', 'exportedParticipantIDs', 'preprocessing', '-v7');
+    fprintf('Exported %d trials to %s\n', size(X, 1), outputFile);
+end

--- a/pytorch_meg_baselines.py
+++ b/pytorch_meg_baselines.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Compact PyTorch baselines for strict no-calibration MEG LOSO decoding.
+
+Models: EEGNet, LF-CNN-style, VAR-CNN-style, and HGRN-style.
+Inputs are trial tensors shaped [trials, channels, time] with labels and subject IDs.
+"""
+from __future__ import annotations
+
+import argparse, csv, json, math, random, tempfile
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+import numpy as np
+import torch
+from torch import nn
+from torch.utils.data import DataLoader, TensorDataset
+
+
+# ----------------------------- models -----------------------------
+class ConvBlock1d(nn.Module):
+    def __init__(self, cin, cout, k, *, groups=1, dilation=1, dropout=0.0):
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Conv1d(cin, cout, k, padding=dilation * (k // 2), dilation=dilation, groups=groups, bias=False),
+            nn.BatchNorm1d(cout), nn.GELU(), nn.Dropout(dropout))
+    def forward(self, x): return self.net(x)
+
+class EEGNet(nn.Module):
+    def __init__(self, n_channels, n_classes, *, f1=8, depth_multiplier=2, temporal_kernel=64, sep_kernel=16, dropout=0.25):
+        super().__init__(); fsp = f1 * depth_multiplier
+        self.net = nn.Sequential(
+            nn.Unflatten(1, (1, n_channels)),
+            nn.Conv2d(1, f1, (1, temporal_kernel), padding=(0, temporal_kernel // 2), bias=False), nn.BatchNorm2d(f1),
+            nn.Conv2d(f1, fsp, (n_channels, 1), groups=f1, bias=False), nn.BatchNorm2d(fsp), nn.ELU(),
+            nn.AvgPool2d((1, 4)), nn.Dropout(dropout),
+            nn.Conv2d(fsp, fsp, (1, sep_kernel), padding=(0, sep_kernel // 2), groups=fsp, bias=False),
+            nn.Conv2d(fsp, fsp, (1, 1), bias=False), nn.BatchNorm2d(fsp), nn.ELU(),
+            nn.AvgPool2d((1, 8)), nn.Dropout(dropout), nn.AdaptiveAvgPool2d((1, 1)), nn.Flatten(), nn.Linear(fsp, n_classes))
+    def forward(self, x): return self.net(x)
+
+class LFCNN(nn.Module):
+    """LF-CNN-style: learned spatial latent factors, then depthwise temporal filters."""
+    def __init__(self, n_channels, n_classes, *, hidden=48, temporal_kernel=31, dropout=0.25):
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Conv1d(n_channels, hidden, 1, bias=False), nn.BatchNorm1d(hidden), nn.GELU(),
+            ConvBlock1d(hidden, hidden, temporal_kernel, groups=hidden, dropout=dropout),
+            nn.Conv1d(hidden, hidden, 1, bias=False), nn.BatchNorm1d(hidden), nn.GELU(), nn.AvgPool1d(4, ceil_mode=True),
+            ConvBlock1d(hidden, hidden, 15, groups=hidden, dropout=dropout),
+            nn.AdaptiveAvgPool1d(1), nn.Flatten(), nn.Dropout(dropout), nn.Linear(hidden, n_classes))
+    def forward(self, x): return self.net(x)
+
+class ResTemporal(nn.Module):
+    def __init__(self, channels, dilation, dropout):
+        super().__init__(); self.block = nn.Sequential(ConvBlock1d(channels, channels, 15, dilation=dilation, dropout=dropout), nn.Conv1d(channels, channels, 1, bias=False), nn.BatchNorm1d(channels)); self.act = nn.GELU()
+    def forward(self, x): return self.act(x + self.block(x))
+
+class VARCNN(nn.Module):
+    """VAR-CNN-style: depthwise lag filters followed by dilated temporal blocks."""
+    def __init__(self, n_channels, n_classes, *, hidden=64, lag_order=8, n_blocks=3, dropout=0.25):
+        super().__init__(); k = lag_order + 1
+        self.net = nn.Sequential(
+            nn.Conv1d(n_channels, n_channels, k, padding=k // 2, groups=n_channels, bias=False), nn.BatchNorm1d(n_channels), nn.GELU(),
+            nn.Conv1d(n_channels, hidden, 1, bias=False), nn.BatchNorm1d(hidden), nn.GELU(), nn.Dropout(dropout),
+            *[ResTemporal(hidden, 2 ** i, dropout) for i in range(n_blocks)],
+            nn.AdaptiveAvgPool1d(1), nn.Flatten(), nn.Dropout(dropout), nn.Linear(hidden, n_classes))
+    def forward(self, x): return self.net(x)
+
+class HGRN(nn.Module):
+    """HGRN-style: spatial projection, GRU temporal model, attention pooling."""
+    def __init__(self, n_channels, n_classes, *, hidden=64, bidirectional=True, dropout=0.25):
+        super().__init__(); self.spatial = nn.Sequential(nn.Conv1d(n_channels, hidden, 1, bias=False), nn.BatchNorm1d(hidden), nn.GELU(), nn.Dropout(dropout))
+        self.gru = nn.GRU(hidden, hidden, batch_first=True, bidirectional=bidirectional); d = hidden * (2 if bidirectional else 1)
+        self.att = nn.Sequential(nn.Linear(d, max(1, d // 2)), nn.Tanh(), nn.Linear(max(1, d // 2), 1)); self.cls = nn.Sequential(nn.Dropout(dropout), nn.Linear(d, n_classes))
+    def forward(self, x):
+        z = self.spatial(x).transpose(1, 2); z, _ = self.gru(z); w = torch.softmax(self.att(z), dim=1); return self.cls((w * z).sum(1))
+
+def make_model(name, n_channels, n_classes, dropout=0.25):
+    table = {"eegnet": EEGNet, "lfcnn": LFCNN, "lf-cnn": LFCNN, "varcnn": VARCNN, "var-cnn": VARCNN, "hgrn": HGRN}
+    if name.lower() not in table: raise ValueError(f"Unknown model {name}; choose {sorted(table)}")
+    return table[name.lower()](n_channels, n_classes, dropout=dropout)
+
+
+# ----------------------------- data + metrics -----------------------------
+@dataclass
+class Dataset:
+    x: np.ndarray; y: np.ndarray; subjects: np.ndarray; label_values: np.ndarray | None = None
+    def __post_init__(self):
+        self.x = np.asarray(self.x, dtype=np.float32); self.y = np.asarray(self.y).reshape(-1); self.subjects = np.asarray(self.subjects).reshape(-1)
+        if self.x.ndim != 3: raise ValueError(f"X must be [trials, channels, time], got {self.x.shape}")
+        if len(self.y) != len(self.x) or len(self.subjects) != len(self.x): raise ValueError("X, y, subjects length mismatch")
+    @property
+    def n_channels(self): return int(self.x.shape[1])
+    @property
+    def n_classes(self): return int(np.unique(self.y).size)
+
+def load_dataset(path: Path, drop_nonpositive=True) -> Dataset:
+    if path.suffix.lower() == ".npz":
+        with np.load(path, allow_pickle=False) as f:
+            x = f["X"] if "X" in f.files else f["x"]; y = f["y"]; s = f["subjects"]
+    else:
+        from scipy.io import loadmat
+        m = loadmat(path, squeeze_me=True); x = m["X"]; y = m["y"]; s = m["subjects"]
+    x = np.asarray(x, dtype=np.float32); y = np.asarray(y).reshape(-1); s = np.asarray(s).reshape(-1)
+    if x.shape[0] != y.shape[0] and x.shape[-1] == y.shape[0]: x = np.moveaxis(x, -1, 0)  # tolerate MATLAB [C,T,N]
+    if drop_nonpositive:
+        keep = y > 0; x, y, s = x[keep], y[keep], s[keep]
+    vals = np.array(sorted(np.unique(y))); enc = np.array([{v: i for i, v in enumerate(vals)}[v] for v in y], dtype=np.int64)
+    return Dataset(x, enc, s, vals)
+
+def fit_standardizer(x):
+    mean = x.mean(axis=(0, 2), keepdims=True); std = x.std(axis=(0, 2), keepdims=True); return mean.astype(np.float32), np.maximum(std, 1e-6).astype(np.float32)
+def standardize(x, mean, std): return ((x - mean) / std).astype(np.float32)
+def bal_acc(y, pred, n_classes):
+    rec = [np.mean(pred[y == c] == c) for c in range(n_classes) if np.any(y == c)]; return float(np.mean(rec))
+def split_masks(subjects, target, n_val_subjects, seed):
+    subjects = np.asarray(subjects); target = int(target) if str(target).isdigit() else target; test = subjects == target
+    source_subjects = np.array(sorted(set(subjects.tolist()) - {target}))
+    rng = np.random.default_rng(seed); n_val = min(max(1, n_val_subjects), max(1, len(source_subjects) - 1)); val_sub = rng.choice(source_subjects, n_val, replace=False)
+    val = np.isin(subjects, val_sub); train = (~test) & (~val)
+    if not np.any(train) or not np.any(test): raise ValueError(f"Invalid split for target={target}")
+    return train, val, test
+
+
+# ----------------------------- training -----------------------------
+@dataclass
+class FoldResult:
+    model: str; target_subject: str; accuracy: float; balanced_accuracy: float; chance: float; n_train: int; n_val: int; n_test: int; best_epoch: int; best_val_accuracy: float
+
+def seed_all(seed):
+    random.seed(seed); np.random.seed(seed); torch.manual_seed(seed); torch.cuda.manual_seed_all(seed)
+
+def loader(x, y, batch, shuffle): return DataLoader(TensorDataset(torch.from_numpy(x).float(), torch.from_numpy(y).long()), batch_size=batch, shuffle=shuffle)
+
+def evaluate(model, dl, device, n_classes):
+    model.eval(); ys = []; ps = []
+    with torch.no_grad():
+        for xb, yb in dl:
+            p = model(xb.to(device)).argmax(1).cpu().numpy(); ps.append(p); ys.append(yb.numpy())
+    y = np.concatenate(ys); p = np.concatenate(ps); return float(np.mean(y == p)), bal_acc(y, p, n_classes)
+
+def train_fold(ds, model_name, target, args, device):
+    train_m, val_m, test_m = split_masks(ds.subjects, target, args.n_val_subjects, args.seed)
+    mean, std = fit_standardizer(ds.x[train_m])
+    xtr, xv, xte = standardize(ds.x[train_m], mean, std), standardize(ds.x[val_m], mean, std), standardize(ds.x[test_m], mean, std)
+    ytr, yv, yte = ds.y[train_m].astype(np.int64), ds.y[val_m].astype(np.int64), ds.y[test_m].astype(np.int64)
+    tr_dl, va_dl, te_dl = loader(xtr, ytr, args.batch_size, True), loader(xv, yv, args.batch_size, False), loader(xte, yte, args.batch_size, False)
+    model = make_model(model_name, ds.n_channels, ds.n_classes, dropout=args.dropout).to(device)
+    counts = np.bincount(ytr, minlength=ds.n_classes).astype(np.float32); w = counts.sum() / np.maximum(counts, 1) / ds.n_classes
+    criterion = nn.CrossEntropyLoss(weight=torch.tensor(w, dtype=torch.float32, device=device) if not args.no_class_weighting else None)
+    opt = torch.optim.AdamW(model.parameters(), lr=args.lr, weight_decay=args.weight_decay); sched = torch.optim.lr_scheduler.CosineAnnealingLR(opt, max(1, args.epochs))
+    best, best_epoch, best_val, bad = None, 0, -math.inf, 0
+    for epoch in range(1, args.epochs + 1):
+        model.train()
+        for xb, yb in tr_dl:
+            opt.zero_grad(set_to_none=True); loss = criterion(model(xb.to(device)), yb.to(device)); loss.backward(); nn.utils.clip_grad_norm_(model.parameters(), 5.0); opt.step()
+        sched.step(); va, _ = evaluate(model, va_dl, device, ds.n_classes)
+        if va > best_val: best_val, best_epoch, best, bad = va, epoch, {k: v.detach().cpu().clone() for k, v in model.state_dict().items()}, 0
+        else: bad += 1
+        if bad >= args.patience: break
+    if best is not None: model.load_state_dict(best)
+    acc, bacc = evaluate(model, te_dl, device, ds.n_classes)
+    return FoldResult(model_name, str(target), acc, bacc, 1 / ds.n_classes, int(train_m.sum()), int(val_m.sum()), int(test_m.sum()), best_epoch, float(best_val))
+
+def write_results(rows, prefix: Path):
+    prefix.parent.mkdir(parents=True, exist_ok=True); dicts = [asdict(r) for r in rows]
+    with prefix.with_suffix(".csv").open("w", newline="") as f: w = csv.DictWriter(f, fieldnames=dicts[0].keys()); w.writeheader(); w.writerows(dicts)
+    summary = {}
+    for m in sorted({r.model for r in rows}):
+        rs = [r for r in rows if r.model == m]; summary[m] = {"mean_accuracy": float(np.mean([r.accuracy for r in rs])), "std_accuracy": float(np.std([r.accuracy for r in rs])), "mean_balanced_accuracy": float(np.mean([r.balanced_accuracy for r in rs])), "chance": rs[0].chance, "n_folds": len(rs)}
+    with prefix.with_suffix(".json").open("w") as f: json.dump({"folds": dicts, "summary": summary}, f, indent=2)
+    print(json.dumps(summary, indent=2)); print(f"Wrote {prefix.with_suffix('.csv')} and {prefix.with_suffix('.json')}")
+
+def run_smoke_test():
+    torch.set_num_threads(1); rng = np.random.default_rng(7); nsub, ncls, ntr, nch, nt = 3, 4, 4, 8, 48
+    templates = rng.normal(size=(ncls, nch, nt)).astype(np.float32) * 0.15; xs=[]; ys=[]; ss=[]
+    for s in range(1, nsub + 1):
+        shift = rng.normal(size=(nch, 1)).astype(np.float32) * 0.05
+        for c in range(ncls):
+            for _ in range(ntr): xs.append(templates[c] + shift + rng.normal(size=(nch, nt)).astype(np.float32) * 0.7); ys.append(c + 1); ss.append(s)
+    with tempfile.TemporaryDirectory() as tmp:
+        p = Path(tmp) / "synthetic.npz"; np.savez(p, X=np.stack(xs), y=np.array(ys), subjects=np.array(ss))
+        main(["--data", str(p), "--models", "eegnet", "lfcnn", "varcnn", "hgrn", "--target-subjects", "1", "--epochs", "1", "--patience", "1", "--batch-size", "8", "--device", "cpu", "--output-prefix", str(Path(tmp) / "smoke")])
+
+def parse(argv=None):
+    ap = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    ap.add_argument("--data", type=Path, help=".npz or .mat tensor file with X, y, subjects")
+    ap.add_argument("--models", nargs="+", default=["eegnet", "lfcnn", "varcnn", "hgrn"])
+    ap.add_argument("--target-subjects", nargs="*", default=None)
+    ap.add_argument("--n-val-subjects", type=int, default=1)
+    ap.add_argument("--epochs", type=int, default=80); ap.add_argument("--patience", type=int, default=15); ap.add_argument("--batch-size", type=int, default=64)
+    ap.add_argument("--lr", type=float, default=1e-3); ap.add_argument("--weight-decay", type=float, default=1e-3); ap.add_argument("--dropout", type=float, default=0.25)
+    ap.add_argument("--no-class-weighting", action="store_true"); ap.add_argument("--include-zero-label", action="store_true"); ap.add_argument("--seed", type=int, default=0)
+    ap.add_argument("--device", default="cuda" if torch.cuda.is_available() else "cpu"); ap.add_argument("--output-prefix", type=Path, default=Path("results/pytorch_loso")); ap.add_argument("--smoke-test", action="store_true")
+    a = ap.parse_args(argv)
+    if not a.smoke_test and a.data is None: ap.error("--data is required unless --smoke-test is used")
+    return a
+
+def main(argv=None):
+    args = parse(argv)
+    if args.smoke_test: return run_smoke_test()
+    seed_all(args.seed); ds = load_dataset(args.data, drop_nonpositive=not args.include_zero_label); device = torch.device(args.device)
+    targets = args.target_subjects or [str(s) for s in sorted(np.unique(ds.subjects).tolist())]
+    results = []
+    for m in args.models:
+        for t in targets:
+            print(f"Training {m}, held-out subject {t}"); r = train_fold(ds, m, t, args, device); print(r); results.append(r)
+    write_results(results, args.output_prefix)
+
+if __name__ == "__main__": main()

--- a/run_cached_public_meg_baselines.py
+++ b/run_cached_public_meg_baselines.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+"""Run the PyTorch MEG baselines on one cached public dataset.
+
+The self-hosted runner is expected to have datasets under
+/home/github-runner/.cache/datasets. This script searches for a compatible
+public MEG representation and converts a small, bounded subset to the
+X/y/subjects tensor expected by pytorch_meg_baselines.py.
+
+Supported inputs, in priority order:
+  1. .npz/.mat files that already contain X, y, subjects arrays.
+  2. MNE Epochs FIF files (*-epo.fif, *-epo.fif.gz, *epo*.fif*).
+
+The goal is a quick strict-LOSO smoke benchmark on real public data, not a final
+hyperparameter-optimized result.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Iterable
+
+import numpy as np
+
+TENSOR_SUFFIXES = {".npz", ".mat"}
+EPOCH_PATTERNS = ("*-epo.fif", "*-epo.fif.gz", "*epo*.fif", "*epo*.fif.gz")
+
+
+def log(msg: str) -> None:
+    print(msg, flush=True)
+
+
+def iter_files(root: Path, max_files: int = 50000) -> Iterable[Path]:
+    count = 0
+    for dirpath, dirnames, filenames in os.walk(root):
+        # Keep traversal bounded and avoid common non-data folders.
+        dirnames[:] = [d for d in dirnames if d not in {".git", "__pycache__", "node_modules"}]
+        for filename in filenames:
+            count += 1
+            if count > max_files:
+                return
+            yield Path(dirpath) / filename
+
+
+def inventory(root: Path, max_entries: int = 200) -> dict:
+    suffix_counts = Counter()
+    examples: list[str] = []
+    for p in iter_files(root):
+        suffix = "".join(p.suffixes[-2:]) if p.name.endswith(".fif.gz") else p.suffix
+        suffix_counts[suffix or "<none>"] += 1
+        if len(examples) < max_entries and (
+            suffix in TENSOR_SUFFIXES or "epo" in p.name.lower() or p.suffix in {".fif", ".gz", ".npy", ".npz", ".mat"}
+        ):
+            examples.append(str(p))
+    return {"root": str(root), "suffix_counts": dict(suffix_counts.most_common(50)), "examples": examples}
+
+
+def try_load_tensor_file(path: Path) -> tuple[np.ndarray, np.ndarray, np.ndarray] | None:
+    try:
+        if path.suffix == ".npz":
+            with np.load(path, allow_pickle=False) as f:
+                keys = set(f.files)
+                x_key = "X" if "X" in keys else "x" if "x" in keys else None
+                y_key = "y" if "y" in keys else "labels" if "labels" in keys else None
+                s_key = "subjects" if "subjects" in keys else "subject" if "subject" in keys else None
+                if not (x_key and y_key and s_key):
+                    return None
+                x, y, subjects = f[x_key], f[y_key], f[s_key]
+        elif path.suffix == ".mat":
+            try:
+                from scipy.io import loadmat
+                m = loadmat(path, squeeze_me=True)
+                if not all(k in m for k in ("X", "y", "subjects")):
+                    return None
+                x, y, subjects = m["X"], m["y"], m["subjects"]
+            except NotImplementedError:
+                # Likely HDF5/v7.3 MAT. Keep this conservative because array
+                # orientation and structs are often dataset-specific.
+                return None
+        else:
+            return None
+        x = np.asarray(x, dtype=np.float32)
+        y = np.asarray(y).reshape(-1)
+        subjects = np.asarray(subjects).reshape(-1)
+        if x.ndim != 3:
+            return None
+        if x.shape[0] != len(y) and x.shape[-1] == len(y):
+            x = np.moveaxis(x, -1, 0)
+        if x.shape[0] == len(y) == len(subjects):
+            return x, y, subjects
+    except Exception as exc:  # noqa: BLE001 - inventory/probing should continue.
+        log(f"Skipping tensor candidate {path}: {exc}")
+    return None
+
+
+def subject_from_path(path: Path) -> str:
+    text = str(path)
+    matches = re.findall(r"sub[-_]?([A-Za-z0-9]+)|subject[-_]?([A-Za-z0-9]+)|participant[-_]?([A-Za-z0-9]+)", text, flags=re.I)
+    for match in reversed(matches):
+        for group in match:
+            if group:
+                return f"sub-{group}"
+    # Fall back to the nearest directory name to avoid making each file a new subject.
+    for parent in path.parents:
+        if parent.name.lower().startswith(("sub", "subject", "participant")):
+            return parent.name
+    return path.parent.name
+
+
+def find_mne_epoch_files(root: Path, limit: int = 200) -> list[Path]:
+    found: list[Path] = []
+    for pattern in EPOCH_PATTERNS:
+        found.extend(root.rglob(pattern))
+    # Deduplicate while preserving deterministic order.
+    unique = sorted(set(found), key=lambda p: str(p))
+    return unique[:limit]
+
+
+def load_mne_epochs(paths: list[Path], *, max_subjects: int, tmin: float | None, tmax: float | None, resample_hz: float | None) -> tuple[np.ndarray, np.ndarray, np.ndarray, dict] | None:
+    try:
+        import mne
+    except Exception as exc:  # noqa: BLE001
+        log(f"MNE is not importable, cannot load FIF epochs: {exc}")
+        return None
+
+    by_subject: dict[str, list[Path]] = defaultdict(list)
+    for p in paths:
+        by_subject[subject_from_path(p)].append(p)
+    selected_subjects = sorted(by_subject)[:max_subjects]
+    xs: list[np.ndarray] = []
+    ys: list[np.ndarray] = []
+    ss: list[np.ndarray] = []
+    used_files: list[str] = []
+
+    for subj in selected_subjects:
+        for p in by_subject[subj]:
+            try:
+                epochs = mne.read_epochs(p, preload=True, verbose="ERROR")
+                if tmin is not None or tmax is not None:
+                    lo = epochs.times[0] if tmin is None else max(float(tmin), float(epochs.times[0]))
+                    hi = epochs.times[-1] if tmax is None else min(float(tmax), float(epochs.times[-1]))
+                    if lo < hi:
+                        epochs.crop(tmin=lo, tmax=hi)
+                if resample_hz is not None and epochs.info["sfreq"] > resample_hz:
+                    epochs.resample(resample_hz, verbose="ERROR")
+                data = epochs.get_data(picks="meg").astype(np.float32)
+                labels = epochs.events[:, 2]
+                if data.ndim != 3 or len(labels) != len(data) or len(np.unique(labels)) < 2:
+                    continue
+                xs.append(data)
+                ys.append(labels)
+                ss.append(np.array([subj] * len(labels), dtype=object))
+                used_files.append(str(p))
+            except Exception as exc:  # noqa: BLE001
+                log(f"Skipping epochs candidate {p}: {exc}")
+    if not xs:
+        return None
+    x = np.concatenate(xs, axis=0)
+    y = np.concatenate(ys, axis=0)
+    subjects = np.concatenate(ss, axis=0)
+    meta = {"kind": "mne_epochs", "used_files": used_files, "selected_subjects": selected_subjects}
+    return x, y, subjects, meta
+
+
+def restrict_dataset(x: np.ndarray, y: np.ndarray, subjects: np.ndarray, *, max_subjects: int, max_classes: int, max_trials_per_subject_class: int, seed: int) -> tuple[np.ndarray, np.ndarray, np.ndarray, dict]:
+    rng = np.random.default_rng(seed)
+    subjects = subjects.astype(str)
+
+    # Remove nonpositive numeric labels if possible; event code 0 is often non-class.
+    try:
+        numeric_y = y.astype(float)
+        keep = numeric_y > 0
+        x, y, subjects = x[keep], y[keep], subjects[keep]
+    except Exception:
+        pass
+
+    class_counts = Counter(y.tolist())
+    selected_classes = [c for c, _ in class_counts.most_common(max_classes)]
+    keep_class = np.isin(y, selected_classes)
+    x, y, subjects = x[keep_class], y[keep_class], subjects[keep_class]
+
+    subject_counts = Counter(subjects.tolist())
+    selected_subjects = [s for s, _ in subject_counts.most_common(max_subjects)]
+    keep_subject = np.isin(subjects, selected_subjects)
+    x, y, subjects = x[keep_subject], y[keep_subject], subjects[keep_subject]
+
+    selected_indices: list[int] = []
+    for subj in sorted(set(subjects.tolist())):
+        for cls in selected_classes:
+            idx = np.where((subjects == subj) & (y == cls))[0]
+            if len(idx) == 0:
+                continue
+            if len(idx) > max_trials_per_subject_class:
+                idx = rng.choice(idx, size=max_trials_per_subject_class, replace=False)
+            selected_indices.extend(idx.tolist())
+    selected_indices = sorted(selected_indices)
+    x, y, subjects = x[selected_indices], y[selected_indices], subjects[selected_indices]
+
+    label_values = np.array(sorted(set(y.tolist()), key=lambda v: str(v)))
+    label_map = {v: i + 1 for i, v in enumerate(label_values)}
+    y_encoded = np.array([label_map[v] for v in y], dtype=np.int64)
+    meta = {
+        "n_trials": int(len(y_encoded)),
+        "n_channels": int(x.shape[1]),
+        "n_times": int(x.shape[2]),
+        "n_subjects": int(len(set(subjects.tolist()))),
+        "n_classes": int(len(label_values)),
+        "chance": float(1.0 / max(1, len(label_values))),
+        "selected_subjects": sorted(set(subjects.tolist())),
+        "label_values": [str(v) for v in label_values.tolist()],
+        "class_counts": {str(k): int(v) for k, v in Counter(y_encoded.tolist()).items()},
+        "subject_counts": {str(k): int(v) for k, v in Counter(subjects.tolist()).items()},
+    }
+    return x.astype(np.float32), y_encoded, subjects.astype(str), meta
+
+
+def find_dataset(args) -> tuple[Path, dict]:
+    root = args.cache_root
+    inv = inventory(root)
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    (args.output_dir / "cache_inventory.json").write_text(json.dumps(inv, indent=2))
+    log("Cache inventory written to " + str(args.output_dir / "cache_inventory.json"))
+    log(json.dumps(inv["suffix_counts"], indent=2)[:4000])
+
+    tensor_candidates = [p for p in iter_files(root) if p.suffix in TENSOR_SUFFIXES]
+    # Prefer files whose name suggests tensors/features/epochs/trials.
+    tensor_candidates.sort(key=lambda p: (not any(k in p.name.lower() for k in ["tensor", "trial", "epoch", "feature", "meg"]), p.stat().st_size if p.exists() else 0))
+    for p in tensor_candidates[: args.max_tensor_candidates]:
+        loaded = try_load_tensor_file(p)
+        if loaded is None:
+            continue
+        x, y, subjects = loaded
+        if len(np.unique(subjects)) < 2 or len(np.unique(y)) < 2:
+            continue
+        x, y, subjects, meta = restrict_dataset(x, y, subjects, max_subjects=args.max_subjects, max_classes=args.max_classes, max_trials_per_subject_class=args.max_trials_per_subject_class, seed=args.seed)
+        meta.update({"kind": "ready_tensor", "source_file": str(p)})
+        out = args.output_dir / "cached_public_meg_subset.npz"
+        np.savez_compressed(out, X=x, y=y, subjects=subjects)
+        (args.output_dir / "dataset_info.json").write_text(json.dumps(meta, indent=2))
+        return out, meta
+
+    epoch_paths = find_mne_epoch_files(root)
+    if epoch_paths:
+        loaded_epochs = load_mne_epochs(epoch_paths, max_subjects=args.max_subjects, tmin=args.tmin, tmax=args.tmax, resample_hz=args.resample_hz)
+        if loaded_epochs is not None:
+            x, y, subjects, source_meta = loaded_epochs
+            x, y, subjects, meta = restrict_dataset(x, y, subjects, max_subjects=args.max_subjects, max_classes=args.max_classes, max_trials_per_subject_class=args.max_trials_per_subject_class, seed=args.seed)
+            meta.update(source_meta)
+            out = args.output_dir / "cached_public_meg_subset.npz"
+            np.savez_compressed(out, X=x, y=y, subjects=subjects)
+            (args.output_dir / "dataset_info.json").write_text(json.dumps(meta, indent=2))
+            return out, meta
+
+    raise RuntimeError(
+        "No compatible cached dataset found. See cache_inventory.json for the files discovered under " + str(root)
+    )
+
+
+def run_baselines(dataset_path: Path, meta: dict, args) -> None:
+    subjects = meta["selected_subjects"][: args.max_target_subjects]
+    cmd = [
+        sys.executable,
+        "pytorch_meg_baselines.py",
+        "--data",
+        str(dataset_path),
+        "--models",
+        *args.models,
+        "--target-subjects",
+        *subjects,
+        "--epochs",
+        str(args.epochs),
+        "--patience",
+        str(args.patience),
+        "--batch-size",
+        str(args.batch_size),
+        "--device",
+        args.device,
+        "--output-prefix",
+        str(args.output_dir / "cached_public_meg_loso"),
+        "--seed",
+        str(args.seed),
+    ]
+    log("Running: " + " ".join(cmd))
+    subprocess.run(cmd, check=True)
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    p.add_argument("--cache-root", type=Path, default=Path("/home/github-runner/.cache/datasets"))
+    p.add_argument("--output-dir", type=Path, default=Path("results/cached_public_meg"))
+    p.add_argument("--models", nargs="+", default=["eegnet", "lfcnn", "varcnn", "hgrn"])
+    p.add_argument("--max-subjects", type=int, default=4)
+    p.add_argument("--max-target-subjects", type=int, default=2)
+    p.add_argument("--max-classes", type=int, default=16)
+    p.add_argument("--max-trials-per-subject-class", type=int, default=30)
+    p.add_argument("--max-tensor-candidates", type=int, default=100)
+    p.add_argument("--tmin", type=float, default=0.0)
+    p.add_argument("--tmax", type=float, default=0.6)
+    p.add_argument("--resample-hz", type=float, default=200.0)
+    p.add_argument("--epochs", type=int, default=8)
+    p.add_argument("--patience", type=int, default=3)
+    p.add_argument("--batch-size", type=int, default=32)
+    p.add_argument("--device", default="cuda" if os.environ.get("CUDA_VISIBLE_DEVICES") else "cpu")
+    p.add_argument("--seed", type=int, default=0)
+    return p.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if not args.cache_root.exists():
+        raise FileNotFoundError(f"Cache root does not exist: {args.cache_root}")
+    dataset_path, meta = find_dataset(args)
+    log("Selected cached dataset subset:")
+    log(json.dumps(meta, indent=2)[:8000])
+    run_baselines(dataset_path, meta, args)
+
+
+if __name__ == "__main__":
+    main()

--- a/run_cached_public_meg_baselines.py
+++ b/run_cached_public_meg_baselines.py
@@ -9,6 +9,7 @@ X/y/subjects tensor expected by pytorch_meg_baselines.py.
 Supported inputs, in priority order:
   1. .npz/.mat files that already contain X, y, subjects arrays.
   2. MNE Epochs FIF files (*-epo.fif, *-epo.fif.gz, *epo*.fif*).
+  3. MNE Raw FIF files with stimulus events, e.g. MNE visual_92_categories.
 
 The goal is a quick strict-LOSO smoke benchmark on real public data, not a final
 hyperparameter-optimized result.
@@ -29,6 +30,10 @@ import numpy as np
 
 TENSOR_SUFFIXES = {".npz", ".mat"}
 EPOCH_PATTERNS = ("*-epo.fif", "*-epo.fif.gz", "*epo*.fif", "*epo*.fif.gz")
+RAW_SKIP_WORDS = (
+    "epo", "epoch", "ave", "cov", "fwd", "inv", "trans", "src", "bem",
+    "head", "fid", "annot", "emptyroom", "erm", "sss_info",
+)
 
 
 def log(msg: str) -> None:
@@ -47,11 +52,15 @@ def iter_files(root: Path, max_files: int = 50000) -> Iterable[Path]:
             yield Path(dirpath) / filename
 
 
+def combined_suffix(path: Path) -> str:
+    return "".join(path.suffixes[-2:]) if path.name.endswith(".fif.gz") else path.suffix
+
+
 def inventory(root: Path, max_entries: int = 200) -> dict:
     suffix_counts = Counter()
     examples: list[str] = []
     for p in iter_files(root):
-        suffix = "".join(p.suffixes[-2:]) if p.name.endswith(".fif.gz") else p.suffix
+        suffix = combined_suffix(p)
         suffix_counts[suffix or "<none>"] += 1
         if len(examples) < max_entries and (
             suffix in TENSOR_SUFFIXES or "epo" in p.name.lower() or p.suffix in {".fif", ".gz", ".npy", ".npz", ".mat"}
@@ -121,11 +130,50 @@ def find_mne_epoch_files(root: Path, limit: int = 200) -> list[Path]:
     return unique[:limit]
 
 
-def load_mne_epochs(paths: list[Path], *, max_subjects: int, tmin: float | None, tmax: float | None, resample_hz: float | None) -> tuple[np.ndarray, np.ndarray, np.ndarray, dict] | None:
+def find_mne_raw_files(root: Path, limit: int = 200) -> list[Path]:
+    candidates: list[Path] = []
+    for p in iter_files(root):
+        suffix = combined_suffix(p)
+        if suffix not in {".fif", ".fif.gz"}:
+            continue
+        name = p.name.lower()
+        if any(word in name for word in RAW_SKIP_WORDS):
+            continue
+        # Avoid separately opening split-file continuations when the first file
+        # points to them internally.
+        if re.search(r"-\d+\.fif(\.gz)?$", name):
+            continue
+        candidates.append(p)
+    # Prioritize likely data files such as raw/tsss/mc files.
+    candidates = sorted(
+        set(candidates),
+        key=lambda p: (
+            not any(k in p.name.lower() for k in ("raw", "tsss", "sss", "meg")),
+            str(p),
+        ),
+    )
+    return candidates[:limit]
+
+
+def import_mne():
     try:
         import mne
+        return mne
     except Exception as exc:  # noqa: BLE001
-        log(f"MNE is not importable, cannot load FIF epochs: {exc}")
+        log(f"MNE is not importable: {exc}")
+        return None
+
+
+def load_mne_epochs(
+    paths: list[Path],
+    *,
+    max_subjects: int,
+    tmin: float | None,
+    tmax: float | None,
+    resample_hz: float | None,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, dict] | None:
+    mne = import_mne()
+    if mne is None:
         return None
 
     by_subject: dict[str, list[Path]] = defaultdict(list)
@@ -167,7 +215,122 @@ def load_mne_epochs(paths: list[Path], *, max_subjects: int, tmin: float | None,
     return x, y, subjects, meta
 
 
-def restrict_dataset(x: np.ndarray, y: np.ndarray, subjects: np.ndarray, *, max_subjects: int, max_classes: int, max_trials_per_subject_class: int, seed: int) -> tuple[np.ndarray, np.ndarray, np.ndarray, dict]:
+def find_events_robust(mne, raw):
+    # Let MNE choose the stim channel first; fall back to common Neuromag names.
+    errors = []
+    for stim_channel in (None, "STI101", "STI 014", "STI102"):
+        try:
+            return mne.find_events(raw, stim_channel=stim_channel, shortest_event=1, verbose="ERROR")
+        except Exception as exc:  # noqa: BLE001
+            errors.append(f"{stim_channel}: {exc}")
+    log("Could not find events. Tried: " + " | ".join(errors))
+    return None
+
+
+def bounded_events(events: np.ndarray, *, max_classes: int, max_trials_per_class: int, event_code_max: int | None, seed: int) -> np.ndarray:
+    events = events[events[:, 2] > 0]
+    if event_code_max is not None:
+        events = events[events[:, 2] <= event_code_max]
+    if len(events) == 0:
+        return events
+    rng = np.random.default_rng(seed)
+    selected_codes = [code for code, _ in Counter(events[:, 2].tolist()).most_common(max_classes)]
+    selected_rows: list[int] = []
+    for code in selected_codes:
+        idx = np.where(events[:, 2] == code)[0]
+        if len(idx) > max_trials_per_class:
+            idx = rng.choice(idx, size=max_trials_per_class, replace=False)
+        selected_rows.extend(idx.tolist())
+    selected_rows = sorted(selected_rows)
+    return events[selected_rows]
+
+
+def load_mne_raw_events(
+    paths: list[Path],
+    *,
+    max_subjects: int,
+    max_classes: int,
+    max_trials_per_subject_class: int,
+    event_code_max: int | None,
+    tmin: float,
+    tmax: float,
+    resample_hz: float | None,
+    seed: int,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, dict] | None:
+    mne = import_mne()
+    if mne is None:
+        return None
+
+    by_subject: dict[str, list[Path]] = defaultdict(list)
+    for p in paths:
+        by_subject[subject_from_path(p)].append(p)
+    selected_subjects = sorted(by_subject)[:max_subjects]
+    xs: list[np.ndarray] = []
+    ys: list[np.ndarray] = []
+    ss: list[np.ndarray] = []
+    used_files: list[str] = []
+
+    for subj in selected_subjects:
+        for p in by_subject[subj]:
+            try:
+                raw = mne.io.read_raw_fif(p, preload=False, on_split_missing="warn", verbose="ERROR")
+                events = find_events_robust(mne, raw)
+                if events is None:
+                    continue
+                events = bounded_events(
+                    events,
+                    max_classes=max_classes,
+                    max_trials_per_class=max_trials_per_subject_class,
+                    event_code_max=event_code_max,
+                    seed=seed,
+                )
+                if len(events) == 0 or len(np.unique(events[:, 2])) < 2:
+                    log(f"Skipping raw candidate {p}: not enough usable event classes after bounding")
+                    continue
+                event_id = {str(code): int(code) for code in sorted(np.unique(events[:, 2]).tolist())}
+                epochs = mne.Epochs(
+                    raw,
+                    events,
+                    event_id=event_id,
+                    tmin=tmin,
+                    tmax=tmax,
+                    baseline=None,
+                    preload=True,
+                    reject_by_annotation=False,
+                    picks="meg",
+                    verbose="ERROR",
+                )
+                if resample_hz is not None and epochs.info["sfreq"] > resample_hz:
+                    epochs.resample(resample_hz, verbose="ERROR")
+                data = epochs.get_data().astype(np.float32)
+                labels = epochs.events[:, 2]
+                if data.ndim != 3 or len(labels) != len(data) or len(np.unique(labels)) < 2:
+                    continue
+                xs.append(data)
+                ys.append(labels)
+                ss.append(np.array([subj] * len(labels), dtype=object))
+                used_files.append(str(p))
+            except Exception as exc:  # noqa: BLE001
+                log(f"Skipping raw candidate {p}: {exc}")
+    if not xs:
+        return None
+    x = np.concatenate(xs, axis=0)
+    y = np.concatenate(ys, axis=0)
+    subjects = np.concatenate(ss, axis=0)
+    meta = {"kind": "mne_raw_events", "used_files": used_files, "selected_subjects": selected_subjects}
+    return x, y, subjects, meta
+
+
+def restrict_dataset(
+    x: np.ndarray,
+    y: np.ndarray,
+    subjects: np.ndarray,
+    *,
+    max_subjects: int,
+    max_classes: int,
+    max_trials_per_subject_class: int,
+    seed: int,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, dict]:
     rng = np.random.default_rng(seed)
     subjects = subjects.astype(str)
 
@@ -216,7 +379,16 @@ def restrict_dataset(x: np.ndarray, y: np.ndarray, subjects: np.ndarray, *, max_
         "class_counts": {str(k): int(v) for k, v in Counter(y_encoded.tolist()).items()},
         "subject_counts": {str(k): int(v) for k, v in Counter(subjects.tolist()).items()},
     }
+    if meta["n_subjects"] < 2 or meta["n_classes"] < 2:
+        raise RuntimeError(f"Need at least 2 subjects and 2 classes after restriction, got {meta}")
     return x.astype(np.float32), y_encoded, subjects.astype(str), meta
+
+
+def save_subset(args, x: np.ndarray, y: np.ndarray, subjects: np.ndarray, meta: dict) -> tuple[Path, dict]:
+    out = args.output_dir / "cached_public_meg_subset.npz"
+    np.savez_compressed(out, X=x, y=y, subjects=subjects)
+    (args.output_dir / "dataset_info.json").write_text(json.dumps(meta, indent=2))
+    return out, meta
 
 
 def find_dataset(args) -> tuple[Path, dict]:
@@ -239,22 +411,45 @@ def find_dataset(args) -> tuple[Path, dict]:
             continue
         x, y, subjects, meta = restrict_dataset(x, y, subjects, max_subjects=args.max_subjects, max_classes=args.max_classes, max_trials_per_subject_class=args.max_trials_per_subject_class, seed=args.seed)
         meta.update({"kind": "ready_tensor", "source_file": str(p)})
-        out = args.output_dir / "cached_public_meg_subset.npz"
-        np.savez_compressed(out, X=x, y=y, subjects=subjects)
-        (args.output_dir / "dataset_info.json").write_text(json.dumps(meta, indent=2))
-        return out, meta
+        return save_subset(args, x, y, subjects, meta)
 
     epoch_paths = find_mne_epoch_files(root)
     if epoch_paths:
+        log(f"Found {len(epoch_paths)} MNE Epochs candidate files")
         loaded_epochs = load_mne_epochs(epoch_paths, max_subjects=args.max_subjects, tmin=args.tmin, tmax=args.tmax, resample_hz=args.resample_hz)
         if loaded_epochs is not None:
             x, y, subjects, source_meta = loaded_epochs
             x, y, subjects, meta = restrict_dataset(x, y, subjects, max_subjects=args.max_subjects, max_classes=args.max_classes, max_trials_per_subject_class=args.max_trials_per_subject_class, seed=args.seed)
             meta.update(source_meta)
-            out = args.output_dir / "cached_public_meg_subset.npz"
-            np.savez_compressed(out, X=x, y=y, subjects=subjects)
-            (args.output_dir / "dataset_info.json").write_text(json.dumps(meta, indent=2))
-            return out, meta
+            return save_subset(args, x, y, subjects, meta)
+
+    raw_paths = find_mne_raw_files(root)
+    if raw_paths:
+        log(f"Found {len(raw_paths)} MNE Raw FIF candidate files")
+        loaded_raw = load_mne_raw_events(
+            raw_paths,
+            max_subjects=args.max_subjects,
+            max_classes=args.max_classes,
+            max_trials_per_subject_class=args.max_trials_per_subject_class,
+            event_code_max=args.event_code_max,
+            tmin=args.tmin,
+            tmax=args.tmax,
+            resample_hz=args.resample_hz,
+            seed=args.seed,
+        )
+        if loaded_raw is not None:
+            x, y, subjects, source_meta = loaded_raw
+            x, y, subjects, meta = restrict_dataset(
+                x,
+                y,
+                subjects,
+                max_subjects=args.max_subjects,
+                max_classes=args.max_classes,
+                max_trials_per_subject_class=args.max_trials_per_subject_class,
+                seed=args.seed,
+            )
+            meta.update(source_meta)
+            return save_subset(args, x, y, subjects, meta)
 
     raise RuntimeError(
         "No compatible cached dataset found. See cache_inventory.json for the files discovered under " + str(root)
@@ -299,6 +494,7 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--max-classes", type=int, default=16)
     p.add_argument("--max-trials-per-subject-class", type=int, default=30)
     p.add_argument("--max-tensor-candidates", type=int, default=100)
+    p.add_argument("--event-code-max", type=int, default=1000)
     p.add_argument("--tmin", type=float, default=0.0)
     p.add_argument("--tmax", type=float, default=0.6)
     p.add_argument("--resample-hz", type=float, default=200.0)

--- a/run_cached_public_meg_baselines.py
+++ b/run_cached_public_meg_baselines.py
@@ -40,16 +40,24 @@ def log(msg: str) -> None:
     print(msg, flush=True)
 
 
+def is_sidecar_or_hidden_data_file(path: Path) -> bool:
+    """Return True for macOS AppleDouble sidecars and other hidden data files."""
+    return path.name.startswith("._") or path.name.startswith(".")
+
+
 def iter_files(root: Path, max_files: int = 50000) -> Iterable[Path]:
     count = 0
     for dirpath, dirnames, filenames in os.walk(root):
         # Keep traversal bounded and avoid common non-data folders.
         dirnames[:] = [d for d in dirnames if d not in {".git", "__pycache__", "node_modules"}]
         for filename in filenames:
+            path = Path(dirpath) / filename
+            if is_sidecar_or_hidden_data_file(path):
+                continue
             count += 1
             if count > max_files:
                 return
-            yield Path(dirpath) / filename
+            yield path
 
 
 def combined_suffix(path: Path) -> str:
@@ -108,23 +116,41 @@ def try_load_tensor_file(path: Path) -> tuple[np.ndarray, np.ndarray, np.ndarray
 
 
 def subject_from_path(path: Path) -> str:
+    """Extract a stable subject identifier from common MEG dataset filenames.
+
+    The ordering matters. We must match full words such as ``sample_subject_0``
+    before the BIDS-style ``sub`` pattern, otherwise ``subject`` can be parsed as
+    ``sub-ject``.
+    """
     text = str(path)
-    matches = re.findall(r"sub[-_]?([A-Za-z0-9]+)|subject[-_]?([A-Za-z0-9]+)|participant[-_]?([A-Za-z0-9]+)", text, flags=re.I)
-    for match in reversed(matches):
-        for group in match:
-            if group:
-                return f"sub-{group}"
+    patterns = [
+        r"sample[_-]subject[_-]?([A-Za-z0-9]+)",
+        r"subject[_-]?([A-Za-z0-9]+)",
+        r"participant[_-]?([A-Za-z0-9]+)",
+        r"(?<![A-Za-z0-9])sub[_-]?([A-Za-z0-9]+)",
+    ]
+    for pattern in patterns:
+        matches = re.findall(pattern, text, flags=re.I)
+        if matches:
+            value = matches[-1]
+            if isinstance(value, tuple):
+                value = next((v for v in value if v), "")
+            if value:
+                return f"sub-{value}"
+
     # Fall back to the nearest directory name to avoid making each file a new subject.
     for parent in path.parents:
-        if parent.name.lower().startswith(("sub", "subject", "participant")):
-            return parent.name
+        name = parent.name
+        lower = name.lower()
+        if lower.startswith(("sub-", "sub_", "subject", "participant")):
+            return name
     return path.parent.name
 
 
 def find_mne_epoch_files(root: Path, limit: int = 200) -> list[Path]:
     found: list[Path] = []
     for pattern in EPOCH_PATTERNS:
-        found.extend(root.rglob(pattern))
+        found.extend(p for p in root.rglob(pattern) if not is_sidecar_or_hidden_data_file(p))
     # Deduplicate while preserving deterministic order.
     unique = sorted(set(found), key=lambda p: str(p))
     return unique[:limit]
@@ -234,7 +260,7 @@ def bounded_events(events: np.ndarray, *, max_classes: int, max_trials_per_class
     if len(events) == 0:
         return events
     rng = np.random.default_rng(seed)
-    selected_codes = [code for code, _ in Counter(events[:, 2].tolist()).most_common(max_classes)]
+    selected_codes = sorted(np.unique(events[:, 2]).tolist())[:max_classes]
     selected_rows: list[int] = []
     for code in selected_codes:
         idx = np.where(events[:, 2] == code)[0]
@@ -343,7 +369,7 @@ def restrict_dataset(
         pass
 
     class_counts = Counter(y.tolist())
-    selected_classes = [c for c, _ in class_counts.most_common(max_classes)]
+    selected_classes = sorted(class_counts.keys(), key=lambda v: str(v))[:max_classes]
     keep_class = np.isin(y, selected_classes)
     x, y, subjects = x[keep_class], y[keep_class], subjects[keep_class]
 


### PR DESCRIPTION
## Summary

Adds a parallel PyTorch path for strict no-calibration LOSO neural baselines:

- `eegnet`: EEGNet-style temporal + depthwise spatial CNN
- `lfcnn`: LF-CNN-style spatial latent filters plus temporal filtering
- `varcnn`: VAR-CNN-style lag/dynamics CNN
- `hgrn`: HGRN-style spatial projection + GRU + attention pooling

Also adds:

- `exportTrialTensorForPyTorch.m`, which reuses the existing MATLAB `preprocessFeatures.m` path to export `X`, `y`, and `subjects` for the PyTorch runner.
- `run_cached_public_meg_baselines.py`, which searches `/home/github-runner/.cache/datasets` for a compatible cached public MEG dataset and converts a bounded subset to `X/y/subjects`.
- `.github/workflows/pytorch_cached_public_meg.yml`, a self-hosted runner workflow that runs the four compact neural baselines on one cached public dataset and uploads CSV/JSON results plus dataset inventory artifacts.

## Strict LOSO hygiene

For each held-out subject, the Python runner:

1. excludes the held-out target subject from training and validation;
2. selects validation subjects from source subjects only;
3. fits channel-wise normalization on source-training trials only;
4. applies the frozen normalizer to validation and held-out target trials;
5. uses the target subject only for final evaluation.

## Cached public data workflow

The self-hosted workflow is configured for:

```yaml
runs-on: [self-hosted, linux]
CACHE_ROOT: /home/github-runner/.cache/datasets
```

The cached-data runner supports, in priority order:

1. ready `.npz` / `.mat` tensors with `X`, `y`, `subjects`;
2. MNE Epochs FIF files;
3. MNE Raw FIF files with stimulus events, e.g. MNE `visual_92_categories`-style raw FIF files.

The default real-data smoke benchmark uses at most 4 subjects, 2 held-out target subjects, 16 classes, 30 trials per subject/class, 8 training epochs, and all four model families. This is intended as a quick real-data sanity check, not a tuned final benchmark.

## Validation

I ran the built-in synthetic-data smoke test locally:

```bash
python pytorch_meg_baselines.py --smoke-test
```

It trains/evaluates EEGNet, LF-CNN, VAR-CNN, and HGRN end-to-end on synthetic data.

A self-hosted GitHub Actions run for the cached public MEG benchmark has been queued by this PR. If the runner is available, it should produce:

- `results/cached_public_meg/cache_inventory.json`
- `results/cached_public_meg/dataset_info.json`
- `results/cached_public_meg/cached_public_meg_loso.csv`
- `results/cached_public_meg/cached_public_meg_loso.json`
