### PR TITLE
Add spatiotemporal branch-fusion SVM classifier

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,3 +47,13 @@ jobs:
           acc = crossValidateSingleDataset('data', 2, 10, 0.1, 0.2, -0.2, inf, '${{ matrix.model }}', nan, 100, [0, inf])
           toc
           assert(acc>0.35)
+
+    - name: Smoke test branch-fusion classifier
+      if: matrix.model == 'multiclass-svm'
+      uses: matlab-actions/run-command@v2
+      with:
+        command: |
+          tic
+          accBranch = crossValidateSingleDataset('data', 2, 2, 0.1, 0.2, nan, inf, 'branch-fusion-svm', nan, 20, [0, inf])
+          toc
+          assert(isfinite(accBranch) && accBranch >= 0 && accBranch <= 1)

--- a/crossValidateMultipleDatasets.m
+++ b/crossValidateMultipleDatasets.m
@@ -16,7 +16,10 @@ function accuracies = crossValidateMultipleDatasets(dataFolder, participantIDs, 
         nullWindowCenter (1, 1) double = -0.2;
         % Set newFramerate to inf to disable downsampling. Set to '100' to emulate the behavior of runLasso.m
         newFramerate (1, 1) double = inf;
-        % Type of classifier to use, e.g. 'lasso', 'multiclass-svm', 'random-forest', 'gradient-boosting', 'knn', 'mostFrequentDummy', 'always1Dummy'.
+        % Type of classifier to use, e.g. 'lasso', 'multiclass-svm',
+        % 'multiclass-svm-weighted', 'branch-fusion-svm',
+        % 'branch-fusion-svm-weighted', 'random-forest',
+        % 'gradient-boosting', 'knn', 'mostFrequentDummy', 'always1Dummy'.
         classifier char = 'multiclass-svm';
         % Param of L1 regularisation of Lasso GLM or box constraint of SVM,
         % number of trees for RF, number of boosting iterations for GBM,

--- a/crossValidateSingleDataset.m
+++ b/crossValidateSingleDataset.m
@@ -20,13 +20,17 @@ function accuracy = crossValidateSingleDataset(dataFolder, participantID, nFolds
         nullWindowCenter (1, 1) double = -0.2;
         % Set newFramerate to inf to disable downsampling. Set to '100' to emulate the behavior of runLasso.m
         newFramerate (1, 1) double = inf;
-        % Type of classifier to use, e.g. 'lasso', 'multiclass-svm', 'random-forest', 'gradient-boosting', 'knn', 'mostFrequentDummy', 'always1Dummy'.
+        % Type of classifier to use, e.g. 'lasso', 'multiclass-svm',
+        % 'multiclass-svm-weighted', 'branch-fusion-svm',
+        % 'branch-fusion-svm-weighted', 'random-forest',
+        % 'gradient-boosting', 'knn', 'mostFrequentDummy', 'always1Dummy'.
         classifier char = 'multiclass-svm';
         % Param of L1 regularisation of Lasso GLM or box constraint of SVM,
         % number of trees for RF, number of boosting iterations for GBM,
         % of neighbors for KNN, etc.
         classifierParam (1, 1) double = nan;
         % Number of components to retain after PCA. Set to inf to keep all components.
+        % For branch-fusion classifiers this is applied independently per branch.
         componentsPCA (1, 1) double = 100;
         frequencyRange (1, 2) double = [0, inf];
     end
@@ -35,26 +39,42 @@ function accuracy = crossValidateSingleDataset(dataFolder, participantID, nFolds
         classifierParam = getDefaultClassifierParam(classifier);
     end
 
+    useBranchFusion = ismember(classifier, {'branch-fusion-svm', 'branch-fusion-svm-weighted'});
+
     % Load the data for that participant
     load([dataFolder filesep 'Part' int2str(participantID) 'Data.mat'], 'data');
     % Extract some basic information
     labels = data.trialinfo;
     nTrials = length(labels);
     nStim = length(unique(labels));
-    [stimuliFeaturesCell, nullFeaturesCell] = preprocessFeatures(data, frequencyRange, newFramerate, windowSize, trainWindowCenter, nullWindowCenter);
-    allFeatures = horzcat(stimuliFeaturesCell{:}, nullFeaturesCell{:});
+
+    if useBranchFusion
+        [stimuliFeaturesByBranch, nullFeaturesByBranch, branchInfo] = preprocessBranchFeatures(data, frequencyRange, newFramerate, ...
+            windowSize, trainWindowCenter, nullWindowCenter);
+        allFeaturesByBranch = cellfun(@(stimFeatures, nullFeatures) horzcat(stimFeatures{:}, nullFeatures{:}), ...
+            stimuliFeaturesByBranch, nullFeaturesByBranch, 'UniformOutput', false);
+        fprintf('Using %d spatiotemporal feature branches.\n', numel(branchInfo))
+    else
+        [stimuliFeaturesCell, nullFeaturesCell] = preprocessFeatures(data, frequencyRange, newFramerate, windowSize, trainWindowCenter, nullWindowCenter);
+        allFeatures = horzcat(stimuliFeaturesCell{:}, nullFeaturesCell{:});
+    end
 
     % Create folds
     fold = ceil((1:length(data.trial)) / (length(data.trial) / nFolds));
-    if ~isempty(nullFeaturesCell)
-        % Assing null data to the same fold as the corresponding stimulus data
+    if (~useBranchFusion && exist('nullFeaturesCell', 'var') && ~isempty(nullFeaturesCell)) || ...
+            (useBranchFusion && ~isempty(nullFeaturesByBranch{1}))
+        % Assign null data to the same fold as the corresponding stimulus data
         fold = [fold, fold];
         labels = [labels, zeros(1, nTrials)];
     end
 
     nTrialsPerFold = nTrials / nFolds;
 
-    allFeats = nan(nFolds, nStim);
+    if useBranchFusion
+        allFeats = nan(nFolds, numel(allFeaturesByBranch));
+    else
+        allFeats = nan(nFolds, nStim);
+    end
     predLbl = nan(nTrials, 1);
 
     % Loop through folds
@@ -62,48 +82,70 @@ function accuracy = crossValidateSingleDataset(dataFolder, participantID, nFolds
         allPred = nan(nTrialsPerFold, nStim);
 
         % Get training and testing data
-        trainFeatures = allFeatures(:, fold ~= f)';
         trainLabels = labels(fold ~= f)';
-        testFeatures = allFeatures(:, fold == f & labels > 0)';
 
-        nFeaturesOrig = size(allFeatures, 1);
-        if componentsPCA ~= inf
-            % Apply PCA to the training data
-            [trainFeatures, coeff, trainFeatureMean, explainedVariance] = reduceFeaturesPCA(trainFeatures, componentsPCA);
-            fprintf('Explained Variance by %d components: %.2f%%\n', componentsPCA, explainedVariance);
-            % Transform the test features using the same PCA transformation
-            testFeatures = (testFeatures - trainFeatureMean) * coeff(:, 1:componentsPCA);
-        end
-        assert(size(trainFeatures, 2) == min(nFeaturesOrig, componentsPCA) && size(testFeatures, 2) == min(nFeaturesOrig, componentsPCA), ...
-            'Feature dimension incorrect.')
+        if useBranchFusion
+            trainFeatures = cellfun(@(branchFeatures) branchFeatures(:, fold ~= f)', ...
+                allFeaturesByBranch, 'UniformOutput', false);
+            testFeatures = cellfun(@(branchFeatures) branchFeatures(:, fold == f & labels > 0)', ...
+                allFeaturesByBranch, 'UniformOutput', false);
 
-        if contains(classifier, {'gradient-boosting', 'lasso', 'svm-binary'})
-            % Iterate over all stimuli for binary classifiers
-            models = cell(1, nStim);
-            for stim = 1:nStim
-                switch classifier
-                    case 'gradient-boosting'
-                        models{stim} = trainGradientBoosting(trainFeatures, double(trainLabels == stim), testFeatures, classifierParam);
-                        allPred(:, stim) = generatePredictionsFromModel(testFeatures, models{stim});
-                    case 'lasso'
-                        models{stim} = trainForStimulusLassoGLM(trainFeatures, double(trainLabels == stim), classifierParam);
-                        allPred(:, stim) = glmval([models{stim}.intercept; models{stim}.beta], testFeatures, 'logit');
-                    case 'svm-binary'
-                        models{stim} = trainBinarySVM(trainFeatures, double(trainLabels == stim), testFeatures, classifierParam);
-                        [~, score] = predict(models{stim}, testFeatures);
-                        allPred(:, stim) = score(:, 2); % The second column contains scores for the positive class
-                    otherwise
-                        error('Unsupported classifier.')
+            if componentsPCA ~= inf
+                for branchIdx = 1:numel(trainFeatures)
+                    nFeaturesOrig = size(trainFeatures{branchIdx}, 2);
+                    nComponents = min(componentsPCA, nFeaturesOrig);
+                    [trainFeatures{branchIdx}, coeff, trainFeatureMean, explainedVariance] = reduceFeaturesPCA(trainFeatures{branchIdx}, nComponents);
+                    fprintf('Branch %d PCA: explained variance by %d components: %.2f%%\n', branchIdx, nComponents, explainedVariance);
+                    testFeatures{branchIdx} = (testFeatures{branchIdx} - trainFeatureMean) * coeff(:, 1:nComponents);
+                    allFeats(f, branchIdx) = nComponents;
                 end
             end
-            % Set to most suitable class
-            [~, predLbl(fold == f & labels > 0)] = max(allPred, [], 2);
-        else
-            % No iteration for multiclass classifiers
-            % Train
+
             model = trainMulticlassClassifier(trainFeatures, trainLabels, classifier, classifierParam);
-            % Predict
             predLbl(fold == f & labels > 0) = generatePredictionsFromModel(testFeatures, model, classifier);
+        else
+            trainFeatures = allFeatures(:, fold ~= f)';
+            testFeatures = allFeatures(:, fold == f & labels > 0)';
+
+            nFeaturesOrig = size(allFeatures, 1);
+            if componentsPCA ~= inf
+                % Apply PCA to the training data
+                [trainFeatures, coeff, trainFeatureMean, explainedVariance] = reduceFeaturesPCA(trainFeatures, componentsPCA);
+                fprintf('Explained Variance by %d components: %.2f%%\n', componentsPCA, explainedVariance);
+                % Transform the test features using the same PCA transformation
+                testFeatures = (testFeatures - trainFeatureMean) * coeff(:, 1:componentsPCA);
+            end
+            assert(size(trainFeatures, 2) == min(nFeaturesOrig, componentsPCA) && size(testFeatures, 2) == min(nFeaturesOrig, componentsPCA), ...
+                'Feature dimension incorrect.')
+
+            if contains(classifier, {'gradient-boosting', 'lasso', 'svm-binary'})
+                % Iterate over all stimuli for binary classifiers
+                models = cell(1, nStim);
+                for stim = 1:nStim
+                    switch classifier
+                        case 'gradient-boosting'
+                            models{stim} = trainGradientBoosting(trainFeatures, double(trainLabels == stim), testFeatures, classifierParam);
+                            allPred(:, stim) = generatePredictionsFromModel(testFeatures, models{stim});
+                        case 'lasso'
+                            models{stim} = trainForStimulusLassoGLM(trainFeatures, double(trainLabels == stim), classifierParam);
+                            allPred(:, stim) = glmval([models{stim}.intercept; models{stim}.beta], testFeatures, 'logit');
+                        case 'svm-binary'
+                            models{stim} = trainBinarySVM(trainFeatures, double(trainLabels == stim), testFeatures, classifierParam);
+                            [~, score] = predict(models{stim}, testFeatures);
+                            allPred(:, stim) = score(:, 2); % The second column contains scores for the positive class
+                        otherwise
+                            error('Unsupported classifier.')
+                    end
+                end
+                % Set to most suitable class
+                [~, predLbl(fold == f & labels > 0)] = max(allPred, [], 2);
+            else
+                % No iteration for multiclass classifiers
+                % Train
+                model = trainMulticlassClassifier(trainFeatures, trainLabels, classifier, classifierParam);
+                % Predict
+                predLbl(fold == f & labels > 0) = generatePredictionsFromModel(testFeatures, model, classifier);
+            end
         end
     end
 
@@ -134,8 +176,8 @@ function accuracy = crossValidateSingleDataset(dataFolder, participantID, nFolds
     nFeatures = allFeats;
     fprintf('Participant %d: %0.2f%% accuracy\n', participantID, accuracy * 100)
 
-    if ~isnan(nFeatures)
-        fprintf('Mean number of features: %0.2f\n', mean(nFeatures, 'all'))
+    if any(~isnan(nFeatures), 'all')
+        fprintf('Mean number of features: %0.2f\n', mean(nFeatures, 'all', 'omitnan'))
     end
 end
 

--- a/crossValidateSingleDataset.m
+++ b/crossValidateSingleDataset.m
@@ -39,7 +39,7 @@ function accuracy = crossValidateSingleDataset(dataFolder, participantID, nFolds
         classifierParam = getDefaultClassifierParam(classifier);
     end
 
-    useBranchFusion = ismember(classifier, {'branch-fusion-svm', 'branch-fusion-svm-weighted'});
+    useBranchFusion = any(strcmp(classifier, {'branch-fusion-svm', 'branch-fusion-svm-weighted'}));
 
     % Load the data for that participant
     load([dataFolder filesep 'Part' int2str(participantID) 'Data.mat'], 'data');

--- a/evaluateModelTransfer.m
+++ b/evaluateModelTransfer.m
@@ -15,13 +15,17 @@ function accuracy = evaluateModelTransfer(dataFolder, parts, windowSize, trainWi
         nullWindowCenter (1, 1) double = -0.2;
         % Set newFramerate to inf to disable downsampling. Set to '100' to emulate the behavior of runLasso.m
         newFramerate (1, 1) double = inf;
-        % Type of classifier to use, e.g. 'lasso', 'multiclass-svm', 'random-forest', 'gradient-boosting', 'knn', 'mostFrequentDummy', 'always1Dummy'.
+        % Type of classifier to use, e.g. 'lasso', 'multiclass-svm',
+        % 'multiclass-svm-weighted', 'branch-fusion-svm',
+        % 'branch-fusion-svm-weighted', 'random-forest',
+        % 'gradient-boosting', 'knn', 'mostFrequentDummy', 'always1Dummy'.
         classifier char = 'multiclass-svm';
         % Param of L1 regularisation of Lasso GLM or box constraint of SVM,
         % number of trees for RF, number of boosting iterations for GBM,
         % of neighbors for KNN, etc.
         classifierParam (1, 1) double = nan;
         % Number of components to retain after PCA. Set to inf to keep all components.
+        % For branch-fusion classifiers this is applied independently per branch.
         componentsPCA (1, 1) double = 100;
         frequencyRange (1, 2) double = [0, inf];
     end
@@ -29,6 +33,9 @@ function accuracy = evaluateModelTransfer(dataFolder, parts, windowSize, trainWi
     if any(isnan(classifierParam))
         classifierParam = getDefaultClassifierParam(classifier);
     end
+
+    useBranchFusion = ismember(classifier, {'branch-fusion-svm', 'branch-fusion-svm-weighted'});
+
     trainExpData = load([dataFolder filesep 'Part' int2str(parts) 'Data.mat']);
     valExpData = load([dataFolder filesep 'Part' int2str(parts) 'CueData.mat']);
 
@@ -38,22 +45,50 @@ function accuracy = evaluateModelTransfer(dataFolder, parts, windowSize, trainWi
     if ~isempty(setdiff(labelsTrainExp, labelsValExp))
         warning('There are labels in the training or validation experiment that are not in the other experiment.')
     end
-    [stimuliFeaturesCellTrainExp, nullFeaturesCellTrainExp] = preprocessFeatures(trainExpData.data, frequencyRange, newFramerate, windowSize, trainWindowCenter, nullWindowCenter);
-    [stimuliFeaturesCellValExp, ~] = preprocessFeatures(valExpData.data, frequencyRange, newFramerate, windowSize, trainWindowCenter, nan);
-    featuresTrainExp = horzcat(stimuliFeaturesCellTrainExp{:}, nullFeaturesCellTrainExp{:})';
-    labelsTrainExp = [labelsTrainExp, zeros(1, length(nullFeaturesCellTrainExp))];
-    featuresValExp = horzcat(stimuliFeaturesCellValExp{:})';
-    
-    if componentsPCA ~= inf
-        [featuresTrainExp, coeff, featuresTrainExpMean, explainedVariance] = reduceFeaturesPCA(featuresTrainExp, componentsPCA);
-        fprintf('Explained Variance by %d components: %.2f%%\n', componentsPCA, explainedVariance);
-        % Transform the features for the validation experiment using the same PCA transformation
-        featuresValExp = (featuresValExp - featuresTrainExpMean) * coeff(:, 1:componentsPCA);
+
+    if useBranchFusion
+        [stimuliFeaturesByBranchTrainExp, nullFeaturesByBranchTrainExp, branchInfo] = preprocessBranchFeatures(trainExpData.data, ...
+            frequencyRange, newFramerate, windowSize, trainWindowCenter, nullWindowCenter);
+        [stimuliFeaturesByBranchValExp, ~] = preprocessBranchFeatures(valExpData.data, ...
+            frequencyRange, newFramerate, windowSize, trainWindowCenter, nan, branchInfo);
+
+        featuresTrainExp = cellfun(@(stimFeatures, nullFeatures) horzcat(stimFeatures{:}, nullFeatures{:})', ...
+            stimuliFeaturesByBranchTrainExp, nullFeaturesByBranchTrainExp, 'UniformOutput', false);
+        featuresValExp = cellfun(@(stimFeatures) horzcat(stimFeatures{:})', ...
+            stimuliFeaturesByBranchValExp, 'UniformOutput', false);
+        labelsTrainExp = [labelsTrainExp, zeros(1, length(nullFeaturesByBranchTrainExp{1}))];
+
+        assert(numel(featuresTrainExp) == numel(featuresValExp), ...
+            'Training and validation experiments produced different numbers of branches.')
+
+        if componentsPCA ~= inf
+            for branchIdx = 1:numel(featuresTrainExp)
+                assert(size(featuresTrainExp{branchIdx}, 2) == size(featuresValExp{branchIdx}, 2), ...
+                    'Training and validation branch feature dimensions differ before PCA.')
+                nFeaturesOrig = size(featuresTrainExp{branchIdx}, 2);
+                nComponents = min(componentsPCA, nFeaturesOrig);
+                [featuresTrainExp{branchIdx}, coeff, featuresTrainExpMean, explainedVariance] = reduceFeaturesPCA(featuresTrainExp{branchIdx}, nComponents);
+                fprintf('Branch %d PCA: explained variance by %d components: %.2f%%\n', branchIdx, nComponents, explainedVariance);
+                featuresValExp{branchIdx} = (featuresValExp{branchIdx} - featuresTrainExpMean) * coeff(:, 1:nComponents);
+            end
+        end
+    else
+        [stimuliFeaturesCellTrainExp, nullFeaturesCellTrainExp] = preprocessFeatures(trainExpData.data, frequencyRange, newFramerate, windowSize, trainWindowCenter, nullWindowCenter);
+        [stimuliFeaturesCellValExp, ~] = preprocessFeatures(valExpData.data, frequencyRange, newFramerate, windowSize, trainWindowCenter, nan);
+        featuresTrainExp = horzcat(stimuliFeaturesCellTrainExp{:}, nullFeaturesCellTrainExp{:})';
+        labelsTrainExp = [labelsTrainExp, zeros(1, length(nullFeaturesCellTrainExp))];
+        featuresValExp = horzcat(stimuliFeaturesCellValExp{:})';
+
+        if componentsPCA ~= inf
+            [featuresTrainExp, coeff, featuresTrainExpMean, explainedVariance] = reduceFeaturesPCA(featuresTrainExp, componentsPCA);
+            fprintf('Explained Variance by %d components: %.2f%%\n', componentsPCA, explainedVariance);
+            % Transform the features for the validation experiment using the same PCA transformation
+            featuresValExp = (featuresValExp - featuresTrainExpMean) * coeff(:, 1:componentsPCA);
+        end
     end
 
     model = trainMulticlassClassifier(featuresTrainExp, labelsTrainExp, classifier, classifierParam);
     predictionsValExp = generatePredictionsFromModel(featuresValExp, model, classifier);
-
 
     accuracy = mean(predictionsValExp == labelsValExp')
 end

--- a/evaluateModelTransfer.m
+++ b/evaluateModelTransfer.m
@@ -34,7 +34,7 @@ function accuracy = evaluateModelTransfer(dataFolder, parts, windowSize, trainWi
         classifierParam = getDefaultClassifierParam(classifier);
     end
 
-    useBranchFusion = ismember(classifier, {'branch-fusion-svm', 'branch-fusion-svm-weighted'});
+    useBranchFusion = any(strcmp(classifier, {'branch-fusion-svm', 'branch-fusion-svm-weighted'}));
 
     trainExpData = load([dataFolder filesep 'Part' int2str(parts) 'Data.mat']);
     valExpData = load([dataFolder filesep 'Part' int2str(parts) 'CueData.mat']);

--- a/generatePredictionsFromModel.m
+++ b/generatePredictionsFromModel.m
@@ -6,10 +6,38 @@ function predictions = generatePredictionsFromModel(testFeatures, model, classif
             predictions = ones(size(testFeatures, 1), 1);
         case {'random-forest', 'multiclass-svm', 'multiclass-svm-weighted', 'knn'}
             [predictions, ~] = predict(model, testFeatures);
+        case {'branch-fusion-svm', 'branch-fusion-svm-weighted'}
+            predictions = generateBranchFusionPredictions(testFeatures, model);
         otherwise
             error('Unsupported classifier.')
     end
     if iscell(predictions) && ischar(predictions{1})
         predictions = str2double(predictions);
     end
+end
+
+function predictions = generateBranchFusionPredictions(testFeaturesByBranch, model)
+    assert(iscell(testFeaturesByBranch), 'Branch-fusion prediction expects a cell array of branch features.')
+    assert(numel(testFeaturesByBranch) == numel(model.branchModels), ...
+        'The number of test branches must match the trained branch-fusion model.')
+
+    classNames = model.classNames(:);
+    nClasses = numel(classNames);
+    nTest = size(testFeaturesByBranch{1}, 1);
+    scoreSum = zeros(nTest, nClasses);
+
+    for b = 1:numel(model.branchModels)
+        assert(size(testFeaturesByBranch{b}, 1) == nTest, ...
+            'All test branch matrices must have the same number of rows.')
+
+        [~, branchScores] = predict(model.branchModels{b}, testFeaturesByBranch{b});
+        branchClassNames = model.branchModels{b}.ClassNames(:);
+        [isKnownClass, classIndices] = ismember(branchClassNames, classNames);
+        assert(all(isKnownClass), 'A branch model returned an unknown class label.')
+
+        scoreSum(:, classIndices) = scoreSum(:, classIndices) + branchScores;
+    end
+
+    [~, bestClassIndex] = max(scoreSum, [], 2);
+    predictions = classNames(bestClassIndex);
 end

--- a/getDefaultClassifierParam.m
+++ b/getDefaultClassifierParam.m
@@ -2,7 +2,8 @@ function classifierParam = getDefaultClassifierParam(classifier)
     switch classifier
         case 'lasso'
             classifierParam = 0.005;
-        case {'multiclass-svm', 'multiclass-svm-weighted', 'binary-svm'}
+        case {'multiclass-svm', 'multiclass-svm-weighted', 'binary-svm', ...
+                'branch-fusion-svm', 'branch-fusion-svm-weighted'}
             classifierParam = 0.5;
         case {'random-forest', 'gradient-boosting'}
             classifierParam = 100;

--- a/preprocessBranchFeatures.m
+++ b/preprocessBranchFeatures.m
@@ -79,7 +79,7 @@ function temporalWindows = getDefaultTemporalWindows(data, windowSize, trainWind
         end
 
         key = sprintf('%.6f_%.6f', currWindow(1), currWindow(2));
-        if ismember(key, seenKeys)
+        if any(strcmp(key, seenKeys))
             continue
         end
 

--- a/preprocessBranchFeatures.m
+++ b/preprocessBranchFeatures.m
@@ -1,0 +1,293 @@
+function [stimuliFeaturesByBranch, nullFeaturesByBranch, branchInfo] = preprocessBranchFeatures(data, frequencyRange, newFramerate, windowSize, trainWindowCenter, nullWindowCenter, branchInfo)
+    % preprocessBranchFeatures Build parallel temporal/spatial feature branches.
+    %
+    % This is the feature extractor for the 'branch-fusion-svm' classifier.
+    % It keeps the source-only hygiene of the existing pipeline: all branch
+    % definitions are fixed from time/channel metadata, while all fitted
+    % transforms such as PCA and SVM standardization remain inside the
+    % training fold.
+    %
+    % Outputs are cell arrays with one entry per branch. Each branch entry is
+    % itself a cell array with one column-vector feature per trial, matching
+    % the convention used by preprocessFeatures.
+
+    if nargin < 7
+        branchInfo = [];
+    end
+
+    % Filter the data
+    data = filterFeaturesForBranches(data, frequencyRange(1), frequencyRange(2));
+
+    % Downsample the data, if required
+    if newFramerate ~= inf
+        data = downsampleDataForBranches(data, newFramerate);
+    end
+
+    if isempty(branchInfo)
+        temporalWindows = getDefaultTemporalWindows(data, windowSize, trainWindowCenter);
+        spatialGroups = inferSpatialGroups(data);
+        branchInfo = makeBranchInfo(temporalWindows, spatialGroups);
+    end
+
+    nBranches = numel(branchInfo);
+    stimuliFeaturesByBranch = cell(1, nBranches);
+    nullFeaturesByBranch = cell(1, nBranches);
+
+    for b = 1:nBranches
+        timeIndices = getTimeIndices(data.time{1}, branchInfo(b).timeWindow);
+        channelIndices = branchInfo(b).channels;
+
+        stimuliFeaturesByBranch{b} = cellfun(@(x) reshape(x(channelIndices, timeIndices), [], 1), ...
+            data.trial, 'UniformOutput', false);
+
+        if any(isnan(nullWindowCenter))
+            nullFeaturesByBranch{b} = {};
+        else
+            duration = diff(branchInfo(b).timeWindow);
+            nullTimeWindow = nullWindowCenter + [-duration / 2, duration / 2];
+            assert(nullTimeWindow(end) <= branchInfo(b).timeWindow(1), 'Null window must be before train window')
+            assert(nullTimeWindow(end) <= 0, 'Null window should not contain positive time points')
+
+            nullBeginIndex = getNearestTimeIndex(data.time{1}, nullTimeWindow(1));
+            nullEndIndex = nullBeginIndex + numel(timeIndices) - 1;
+            assert(nullEndIndex <= numel(data.time{1}), 'Null window exceeds available time range')
+            nullTimeIndices = nullBeginIndex:nullEndIndex;
+
+            nullFeaturesByBranch{b} = cellfun(@(x) reshape(x(channelIndices, nullTimeIndices), [], 1), ...
+                data.trial, 'UniformOutput', false);
+        end
+    end
+end
+
+function temporalWindows = getDefaultTemporalWindows(data, windowSize, trainWindowCenter)
+    mainWindow = trainWindowCenter + [-windowSize / 2, windowSize / 2];
+
+    candidateNames = {'main', 'early_visual', 'mid_visual', 'late_visual'};
+    candidateWindows = [
+        mainWindow;
+        0.05, 0.15;
+        0.15, 0.30;
+        0.30, 0.50
+    ];
+
+    temporalWindows = struct('name', {}, 'window', {});
+    seenKeys = {};
+    for i = 1:size(candidateWindows, 1)
+        currWindow = candidateWindows(i, :);
+        if i ~= 1 && ~isWindowInsideData(currWindow, data.time{1})
+            continue
+        end
+
+        key = sprintf('%.6f_%.6f', currWindow(1), currWindow(2));
+        if ismember(key, seenKeys)
+            continue
+        end
+
+        temporalWindows(end + 1).name = candidateNames{i}; %#ok<AGROW>
+        temporalWindows(end).window = currWindow;
+        seenKeys{end + 1} = key; %#ok<AGROW>
+    end
+
+    assert(~isempty(temporalWindows), 'No valid temporal branch windows found')
+end
+
+function isInside = isWindowInsideData(timeWindow, time)
+    tolerance = 0.5 * median(diff(time));
+    isInside = timeWindow(1) >= min(time) - tolerance && ...
+        timeWindow(2) <= max(time) + tolerance && ...
+        timeWindow(2) > timeWindow(1);
+end
+
+function spatialGroups = inferSpatialGroups(data)
+    nChannels = size(data.trial{1}, 1);
+    spatialGroups = struct('name', 'all', 'indices', 1:nChannels);
+
+    channelPositions = getChannelPositions(data, nChannels);
+    if isempty(channelPositions) || size(channelPositions, 2) < 2
+        return
+    end
+
+    x = channelPositions(:, 1);
+    y = channelPositions(:, 2);
+    if any(~isfinite(x)) || any(~isfinite(y))
+        return
+    end
+
+    spatialGroups = addSpatialGroup(spatialGroups, 'posterior', y <= median(y));
+    spatialGroups = addSpatialGroup(spatialGroups, 'left', x < median(x));
+    spatialGroups = addSpatialGroup(spatialGroups, 'right', x >= median(x));
+end
+
+function spatialGroups = addSpatialGroup(spatialGroups, name, mask)
+    mask = mask(:)';
+    indices = find(mask);
+    nChannels = numel(mask);
+
+    if numel(indices) < 2 || numel(indices) == nChannels
+        return
+    end
+
+    for i = 1:numel(spatialGroups)
+        if isequal(spatialGroups(i).indices, indices)
+            return
+        end
+    end
+
+    spatialGroups(end + 1).name = name; %#ok<AGROW>
+    spatialGroups(end).indices = indices;
+end
+
+function channelPositions = getChannelPositions(data, nChannels)
+    channelPositions = [];
+    labels = getDataLabels(data, nChannels);
+
+    if isfield(data, 'grad') && isfield(data.grad, 'chanpos')
+        candidatePositions = data.grad.chanpos;
+        candidateLabels = getFieldIfPresent(data.grad, 'label');
+        channelPositions = alignChannelPositions(labels, candidateLabels, candidatePositions, nChannels);
+        if ~isempty(channelPositions)
+            return
+        end
+
+        if size(candidatePositions, 1) >= nChannels
+            channelPositions = candidatePositions(1:nChannels, :);
+            return
+        end
+    end
+
+    if isfield(data, 'elec') && isfield(data.elec, 'chanpos')
+        candidatePositions = data.elec.chanpos;
+        candidateLabels = getFieldIfPresent(data.elec, 'label');
+        channelPositions = alignChannelPositions(labels, candidateLabels, candidatePositions, nChannels);
+        if ~isempty(channelPositions)
+            return
+        end
+
+        if size(candidatePositions, 1) >= nChannels
+            channelPositions = candidatePositions(1:nChannels, :);
+            return
+        end
+    end
+end
+
+function labels = getDataLabels(data, nChannels)
+    labels = {};
+    if isfield(data, 'label')
+        labels = data.label;
+    elseif isfield(data, 'grad') && isfield(data.grad, 'label') && numel(data.grad.label) >= nChannels
+        labels = data.grad.label(1:nChannels);
+    end
+
+    if isstring(labels)
+        labels = cellstr(labels);
+    end
+    labels = labels(:);
+end
+
+function value = getFieldIfPresent(s, fieldName)
+    if isfield(s, fieldName)
+        value = s.(fieldName);
+    else
+        value = {};
+    end
+end
+
+function channelPositions = alignChannelPositions(labels, candidateLabels, candidatePositions, nChannels)
+    channelPositions = [];
+    if isempty(labels) || isempty(candidateLabels) || size(candidatePositions, 1) < nChannels
+        return
+    end
+
+    if isstring(candidateLabels)
+        candidateLabels = cellstr(candidateLabels);
+    end
+    candidateLabels = candidateLabels(:);
+
+    if numel(labels) ~= nChannels
+        return
+    end
+
+    alignedPositions = nan(nChannels, size(candidatePositions, 2));
+    for i = 1:nChannels
+        matchIndex = find(strcmp(candidateLabels, labels{i}), 1);
+        if isempty(matchIndex)
+            return
+        end
+        alignedPositions(i, :) = candidatePositions(matchIndex, :);
+    end
+    channelPositions = alignedPositions;
+end
+
+function branchInfo = makeBranchInfo(temporalWindows, spatialGroups)
+    branchInfo = struct('name', {}, 'timeWindow', {}, 'channels', {}, 'temporalBranch', {}, 'channelGroup', {});
+    branchIdx = 0;
+
+    for t = 1:numel(temporalWindows)
+        for g = 1:numel(spatialGroups)
+            branchIdx = branchIdx + 1;
+            branchInfo(branchIdx).name = [temporalWindows(t).name '_' spatialGroups(g).name];
+            branchInfo(branchIdx).timeWindow = temporalWindows(t).window;
+            branchInfo(branchIdx).channels = spatialGroups(g).indices;
+            branchInfo(branchIdx).temporalBranch = temporalWindows(t).name;
+            branchInfo(branchIdx).channelGroup = spatialGroups(g).name;
+        end
+    end
+end
+
+function indices = getTimeIndices(time, timeWindow)
+    assert(diff(timeWindow) >= 0, 'Time window ill defined')
+    beginIndex = getNearestTimeIndex(time, timeWindow(1));
+    endIndex = getNearestTimeIndex(time, timeWindow(2));
+    if endIndex < beginIndex
+        tmp = beginIndex;
+        beginIndex = endIndex;
+        endIndex = tmp;
+    end
+    indices = beginIndex:endIndex;
+end
+
+function index = getNearestTimeIndex(time, targetTime)
+    [~, index] = min(abs(time - targetTime));
+end
+
+function newData = filterFeaturesForBranches(data, lowFreq, highFreq)
+    newData = data;
+
+    if isempty(data.time{1})
+        error('Time vector is empty or not provided correctly.');
+    end
+
+    Fs = 1 / mean(diff(data.time{1}));
+    assert(lowFreq >= 0, 'Low frequency must be greater than or equal to 0')
+    assert(highFreq >= 0, 'High frequency must be greater than or equal to 0')
+    assert(highFreq >= lowFreq, 'High frequency must be greater than or equal to low frequency')
+
+    if lowFreq == 0 && highFreq == inf
+        return
+    elseif lowFreq == 0 && highFreq ~= inf
+        [b, a] = butter(4, highFreq / (Fs / 2), 'low');
+    elseif lowFreq ~= 0 && highFreq ~= inf
+        [b, a] = butter(4, [lowFreq highFreq] / (Fs / 2), 'bandpass');
+    else
+        error('Highpass filter not supported.')
+    end
+
+    for i = 1:length(data.trial)
+        newData.trial{i} = filtfilt(b, a, data.trial{i}.');
+        newData.trial{i} = newData.trial{i}.';
+    end
+end
+
+function data = downsampleDataForBranches(data, newFramerate)
+    rawFs = round(1 / median(diff(data.time{1})));
+
+    if ~isempty(newFramerate) && rawFs ~= newFramerate
+        newT = data.time{1}(1):1 / newFramerate:data.time{1}(end);
+
+        for t = 1:length(data.trial)
+            data.trial{t} = detrend(data.trial{t}')';
+            data.trial{t} = interp1(data.time{t}, data.trial{t}', newT)';
+            data.time{t} = newT;
+        end
+    end
+end

--- a/trainMulticlassClassifier.m
+++ b/trainMulticlassClassifier.m
@@ -7,10 +7,14 @@ function model = trainMulticlassClassifier(trainFeatures, trainLabels, classifie
             model = trainMulticlassSVM(trainFeatures, trainLabels, classifierParam, false);
         case 'multiclass-svm-weighted'
             model = trainMulticlassSVM(trainFeatures, trainLabels, classifierParam, true);
+        case 'branch-fusion-svm'
+            model = trainBranchFusionSVM(trainFeatures, trainLabels, classifierParam, false);
+        case 'branch-fusion-svm-weighted'
+            model = trainBranchFusionSVM(trainFeatures, trainLabels, classifierParam, true);
         case 'knn'
             model = trainKNN(trainFeatures, trainLabels, classifierParam);
         case 'mostFrequentDummy'
-            frequencies = histcounts(labels(labels > 0));
+            frequencies = histcounts(trainLabels(trainLabels > 0));
             [~, model] = max(frequencies);
         case 'always1Dummy'
             % No training required for this classifier
@@ -30,20 +34,46 @@ function model = trainMulticlassSVM(trainFeatures, trainLabels, boxConstraint, w
         model = fitcecoc(trainFeatures, trainLabels, 'Coding', 'onevsone', ...
             'Learners', t, 'Weights', calculateObservationWeights(trainLabels));
     end
+end
 
-    function weightsObs = calculateObservationWeights(labels)
-        % Calculate observation weights based on class frequency
-        [frequencies, labelNames] = histcounts(categorical(labels));
-        weightsClass = 1 ./ frequencies;
-        weightsObs = nan(size(labels));
+function model = trainBranchFusionSVM(trainFeaturesByBranch, trainLabels, boxConstraint, weighted)
+    % Train one linear ECOC SVM per feature branch. At prediction time, the
+    % per-branch class scores are summed. This implements a lightweight
+    % parallel temporal/spatial branch model without adding a deep-learning
+    % dependency and without using any held-out target data for fitting.
+    assert(iscell(trainFeaturesByBranch), 'Branch-fusion classifiers expect a cell array of branch features.')
+    assert(~isempty(trainFeaturesByBranch), 'At least one branch is required for branch-fusion classification.')
 
-        for i = 1:numel(frequencies)
-            weightsObs(labels == str2double(labelNames{i})) = weightsClass(i);
+    nBranches = numel(trainFeaturesByBranch);
+    model = struct();
+    model.branchModels = cell(1, nBranches);
+    model.classNames = [];
+    model.fusion = 'sum-score';
+
+    for b = 1:nBranches
+        assert(size(trainFeaturesByBranch{b}, 1) == numel(trainLabels), ...
+            'All branch feature matrices must have one row per training label.')
+        model.branchModels{b} = trainMulticlassSVM(trainFeaturesByBranch{b}, trainLabels, boxConstraint, weighted);
+        if b == 1
+            model.classNames = model.branchModels{b}.ClassNames;
+        else
+            assert(isequal(model.classNames, model.branchModels{b}.ClassNames), ...
+                'All branch models must use the same class order.')
         end
+    end
+end
 
-        weightsObs = weightsObs / sum(weightsObs); % Normalize weights
+function weightsObs = calculateObservationWeights(labels)
+    % Calculate observation weights based on class frequency
+    [frequencies, labelNames] = histcounts(categorical(labels));
+    weightsClass = 1 ./ frequencies;
+    weightsObs = nan(size(labels));
+
+    for i = 1:numel(frequencies)
+        weightsObs(labels == str2double(labelNames{i})) = weightsClass(i);
     end
 
+    weightsObs = weightsObs / sum(weightsObs); % Normalize weights
 end
 
 function model = trainRandomForest(trainFeatures, trainLabels,  classifierParam)


### PR DESCRIPTION
## Summary

Adds a source-only spatiotemporal branch-fusion classifier for the proposed parallel temporal + spatial branch approach.

### What changed

- Adds `preprocessBranchFeatures.m` to build fixed temporal/spatial feature branches:
  - user-specified main window
  - early visual window: 50-150 ms
  - mid visual window: 150-300 ms
  - late visual window: 300-500 ms
  - all sensors plus optional geometry-derived posterior/left/right groups when channel positions are available
- Registers two new classifiers:
  - `branch-fusion-svm`
  - `branch-fusion-svm-weighted`
- Trains one linear ECOC SVM per branch and fuses class scores by summation.
- Applies PCA source-only inside each CV fold, independently per branch.
- Supports the new classifier in both:
  - `crossValidateSingleDataset`
  - `evaluateModelTransfer`

## Strictness / leakage note

The branch definitions use only fixed time windows and channel metadata. PCA, SVM standardization, class weighting, and model fitting are done inside the training split. Held-out fold data are only transformed with source-fitted PCA and evaluated.

## Example

```matlab
acc = crossValidateSingleDataset('data', 2, 10, 0.1, 0.2, -0.2, inf, ...
    'branch-fusion-svm', nan, 100, [0, inf])
```

## Validation

I could not run MATLAB from the sandbox environment, so this PR relies on GitHub Actions / repository CI for execution validation.